### PR TITLE
Update submodule and patches

### DIFF
--- a/patches/0046-ffmpeg-Add-DX11-support-for-QSV.patch
+++ b/patches/0046-ffmpeg-Add-DX11-support-for-QSV.patch
@@ -1,25 +1,25 @@
-From 51ef04334727c291dd567557603beb76ff719c6f Mon Sep 17 00:00:00 2001
+From 7d58c6ccf304cd3c1b672338706fa0d479ef7fae Mon Sep 17 00:00:00 2001
 From: "Galin, Artem" <artem.galin@intel.com>
 Date: Tue, 26 May 2020 14:28:46 +0800
 Subject: [PATCH] ffmpeg: Add DX11 support for QSV
 
 ---
  fftools/ffmpeg_opt.c             |   6 +-
- libavcodec/qsv.c                 |  53 ++++--
+ libavcodec/qsv.c                 |  53 ++--
  libavcodec/qsv_internal.h        |   2 +-
- libavfilter/qsvvpp.c             |  33 ++--
- libavfilter/vf_deinterlace_qsv.c |  44 +++--
- libavfilter/vf_scale_qsv.c       |  45 +++--
- libavutil/hwcontext_d3d11va.c    |  65 ++++++-
+ libavfilter/qsvvpp.c             |  34 +--
+ libavfilter/vf_deinterlace_qsv.c |  51 ++--
+ libavfilter/vf_scale_qsv.c       |  52 ++--
+ libavutil/hwcontext_d3d11va.c    |  65 ++++-
  libavutil/hwcontext_d3d11va.h    |   7 +
- libavutil/hwcontext_qsv.c        | 400 +++++++++++++++++++++++++++++++--------
- 9 files changed, 500 insertions(+), 155 deletions(-)
+ libavutil/hwcontext_qsv.c        | 400 +++++++++++++++++++++++++------
+ 9 files changed, 509 insertions(+), 161 deletions(-)
 
 diff --git a/fftools/ffmpeg_opt.c b/fftools/ffmpeg_opt.c
-index c7f3b13..0117d39 100644
+index bf2eb26246..60111bee55 100644
 --- a/fftools/ffmpeg_opt.c
 +++ b/fftools/ffmpeg_opt.c
-@@ -559,7 +559,11 @@ static int opt_init_hw_device(void *optctx, const char *opt, const char *arg)
+@@ -579,7 +579,11 @@ static int opt_init_hw_device(void *optctx, const char *opt, const char *arg)
          printf("\n");
          exit_program(0);
      } else {
@@ -33,7 +33,7 @@ index c7f3b13..0117d39 100644
  }
  
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 731fd35..8709c87 100644
+index f2d3b74a96..dadfb83889 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -36,6 +36,8 @@
@@ -45,7 +45,7 @@ index 731fd35..8709c87 100644
  #if QSV_VERSION_ATLEAST(1, 12)
  #include "mfx/mfxvp8.h"
  #endif
-@@ -253,7 +255,9 @@ int ff_qsv_find_surface_idx(QSVFramesContext *ctx, QSVFrame *frame)
+@@ -257,7 +259,9 @@ int ff_qsv_find_surface_idx(QSVFramesContext *ctx, QSVFrame *frame)
      int i;
      for (i = 0; i < ctx->nb_mids; i++) {
          QSVMid *mid = &ctx->mids[i];
@@ -56,7 +56,7 @@ index 731fd35..8709c87 100644
              return i;
      }
      return AVERROR_BUG;
-@@ -394,7 +398,11 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
+@@ -397,7 +401,11 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
  int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
                                   const char *load_plugins, int gpu_copy)
  {
@@ -68,7 +68,7 @@ index 731fd35..8709c87 100644
      mfxVersion        ver = { { QSV_VERSION_MINOR, QSV_VERSION_MAJOR } };
      mfxInitParam init_par = { MFX_IMPL_AUTO_ANY };
  
-@@ -483,7 +491,7 @@ static AVBufferRef *qsv_create_mids(AVBufferRef *hw_frames_ref)
+@@ -486,7 +494,7 @@ static AVBufferRef *qsv_create_mids(AVBufferRef *hw_frames_ref)
  
      for (i = 0; i < nb_surfaces; i++) {
          QSVMid *mid = &mids[i];
@@ -77,7 +77,7 @@ index 731fd35..8709c87 100644
          mid->hw_frames_ref = hw_frames_ref1;
      }
  
-@@ -660,7 +668,7 @@ static mfxStatus qsv_frame_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
+@@ -663,7 +671,7 @@ static mfxStatus qsv_frame_lock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
          goto fail;
  
      qsv_mid->surf.Info = hw_frames_hwctx->surfaces[0].Info;
@@ -86,7 +86,7 @@ index 731fd35..8709c87 100644
  
      /* map the data to the system memory */
      ret = av_hwframe_map(qsv_mid->locked_frame, qsv_mid->hw_frame,
-@@ -693,7 +701,13 @@ static mfxStatus qsv_frame_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
+@@ -696,7 +704,13 @@ static mfxStatus qsv_frame_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
  static mfxStatus qsv_frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
  {
      QSVMid *qsv_mid = (QSVMid*)mid;
@@ -101,7 +101,7 @@ index 731fd35..8709c87 100644
      return MFX_ERR_NONE;
  }
  
-@@ -701,24 +715,19 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+@@ -704,24 +718,19 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
                                 AVBufferRef *device_ref, const char *load_plugins,
                                 int gpu_copy)
  {
@@ -128,7 +128,7 @@ index 731fd35..8709c87 100644
  
      err = MFXQueryIMPL(parent_session, &impl);
      if (err == MFX_ERR_NONE)
-@@ -727,13 +736,23 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+@@ -730,13 +739,23 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
          return ff_qsv_print_error(avctx, err,
                                    "Error querying the session attributes");
  
@@ -159,10 +159,10 @@ index 731fd35..8709c87 100644
      if (!handle) {
          av_log(avctx, AV_LOG_VERBOSE, "No supported hw handle could be retrieved "
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 6489836..370ab46 100644
+index 6b2fbbe252..5d276b091c 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
-@@ -60,7 +60,7 @@
+@@ -62,7 +62,7 @@
  
  typedef struct QSVMid {
      AVBufferRef *hw_frames_ref;
@@ -172,7 +172,7 @@ index 6489836..370ab46 100644
      AVFrame *locked_frame;
      AVFrame *hw_frame;
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 8d5ff2e..c89d418 100644
+index f216b3f248..ce1261eda4 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -36,6 +36,7 @@
@@ -195,8 +195,8 @@ index 8d5ff2e..c89d418 100644
 -
  static const AVRational default_tb = { 1, 90000 };
  
- /* functions for frameAlloc */
-@@ -129,7 +124,13 @@ static mfxStatus frame_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
+ static const struct {
+@@ -233,7 +228,13 @@ static mfxStatus frame_unlock(mfxHDL pthis, mfxMemId mid, mfxFrameData *ptr)
  
  static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
  {
@@ -211,7 +211,7 @@ index 8d5ff2e..c89d418 100644
      return MFX_ERR_NONE;
  }
  
-@@ -451,7 +452,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -555,7 +556,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
  
          s->out_mem_mode = IS_OPAQUE_MEMORY(s->in_mem_mode) ?
                            MFX_MEMTYPE_OPAQUE_FRAME :
@@ -220,7 +220,7 @@ index 8d5ff2e..c89d418 100644
  
          out_frames_ctx   = (AVHWFramesContext *)out_frames_ref->data;
          out_frames_hwctx = out_frames_ctx->hwctx;
-@@ -497,14 +498,18 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -601,14 +602,19 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
          return AVERROR_UNKNOWN;
      }
  
@@ -242,11 +242,12 @@ index 8d5ff2e..c89d418 100644
      }
  
 +    ret = MFXVideoCORE_GetHandle(device_hwctx->session, handle_type, &handle);
-     if (ret != MFX_ERR_NONE) {
-         av_log(avctx, AV_LOG_ERROR, "Error getting the session handle\n");
-         return AVERROR_UNKNOWN;
++
+     if (ret < 0)
+         return ff_qsvvpp_print_error(avctx, ret, "Error getting the session handle");
+     else if (ret > 0) {
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index 80217c8..f7f9d91 100644
+index 89a282f99e..c27a5b037d 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -42,6 +42,8 @@
@@ -282,7 +283,7 @@ index 80217c8..f7f9d91 100644
  static int init_out_session(AVFilterContext *ctx)
  {
  
-@@ -183,26 +185,30 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -183,29 +185,34 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -319,14 +320,21 @@ index 80217c8..f7f9d91 100644
 +        return AVERROR_UNKNOWN;
      }
  
--    if (err != MFX_ERR_NONE) {
+-    if (err < 0)
+-        return ff_qsvvpp_print_error(ctx, err, "Error getting the session handle");
+-    else if (err > 0) {
+-        ff_qsvvpp_print_warning(ctx, err, "Warning in getting the session handle");
 +    ret = MFXVideoCORE_GetHandle(device_hwctx->session, handle_type, &handle);
-+    if (ret != MFX_ERR_NONE) {
-         av_log(ctx, AV_LOG_ERROR, "Error getting the session handle\n");
++
++    if (ret < 0)
++        return ff_qsvvpp_print_error(ctx, ret, "Error getting the session handle");
++    else if (ret > 0) {
++        ff_qsvvpp_print_warning(ctx, ret, "Warning in getting the session handle");
          return AVERROR_UNKNOWN;
      }
+ 
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 5064dcb..9eb5932 100644
+index 2ac2373955..3e9b116f33 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -70,6 +70,7 @@ enum var_name {
@@ -370,7 +378,7 @@ index 5064dcb..9eb5932 100644
  static int init_out_session(AVFilterContext *ctx)
  {
  
-@@ -292,28 +293,32 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -292,31 +293,36 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -409,14 +417,21 @@ index 5064dcb..9eb5932 100644
 +        return AVERROR_UNKNOWN;
      }
  
--    if (err != MFX_ERR_NONE) {
+-    if (err < 0)
+-        return ff_qsvvpp_print_error(ctx, err, "Error getting the session handle");
+-    else if (err > 0) {
+-        ff_qsvvpp_print_warning(ctx, err, "Warning in getting the session handle");
 +    ret = MFXVideoCORE_GetHandle(device_hwctx->session, handle_type, &handle);
-+    if (ret != MFX_ERR_NONE) {
-         av_log(ctx, AV_LOG_ERROR, "Error getting the session handle\n");
++
++    if (ret < 0)
++        return ff_qsvvpp_print_error(ctx, ret, "Error getting the session handle");
++    else if (ret > 0) {
++        ff_qsvvpp_print_warning(ctx, ret, "Warning in getting the session handle");
          return AVERROR_UNKNOWN;
      }
+ 
 diff --git a/libavutil/hwcontext_d3d11va.c b/libavutil/hwcontext_d3d11va.c
-index c8ae58f..2d84064 100644
+index c8ae58f908..2d8406427a 100644
 --- a/libavutil/hwcontext_d3d11va.c
 +++ b/libavutil/hwcontext_d3d11va.c
 @@ -72,8 +72,8 @@ static av_cold void load_functions(void)
@@ -564,7 +579,7 @@ index c8ae58f..2d84064 100644
          }
      }
 diff --git a/libavutil/hwcontext_d3d11va.h b/libavutil/hwcontext_d3d11va.h
-index 9f91e9b..dd782bc 100644
+index 9f91e9b1b6..dd782bcc12 100644
 --- a/libavutil/hwcontext_d3d11va.h
 +++ b/libavutil/hwcontext_d3d11va.h
 @@ -164,6 +164,13 @@ typedef struct AVD3D11VAFramesContext {
@@ -582,7 +597,7 @@ index 9f91e9b..dd782bc 100644
  
  #endif /* AVUTIL_HWCONTEXT_D3D11VA_H */
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 68681cc..8285ce0 100644
+index 68681cc88e..8285ce03b5 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -27,9 +27,13 @@
@@ -616,10 +631,11 @@ index 68681cc..8285ce0 100644
      int             nb_surfaces_used;
  
      // used in the frame allocator for non-opaque surfaces
-@@ -86,20 +93,6 @@ typedef struct QSVFramesContext {
+@@ -85,20 +92,6 @@ typedef struct QSVFramesContext {
+     mfxExtBuffer *ext_buffers[1];
  } QSVFramesContext;
  
- static const struct {
+-static const struct {
 -    mfxHandleType handle_type;
 -    enum AVHWDeviceType device_type;
 -    enum AVPixelFormat  pix_fmt;
@@ -633,10 +649,9 @@ index 68681cc..8285ce0 100644
 -    { 0 },
 -};
 -
--static const struct {
+ static const struct {
      enum AVPixelFormat pix_fmt;
      uint32_t           fourcc;
- } supported_pixel_formats[] = {
 @@ -133,28 +126,32 @@ static uint32_t qsv_fourcc_from_pix_fmt(enum AVPixelFormat pix_fmt)
      return 0;
  }
@@ -1238,5 +1253,5 @@ index 68681cc..8285ce0 100644
      return qsv_device_derive_from_child(ctx, impl, child_device, 0);
  }
 -- 
-2.7.4
+2.17.1
 

--- a/patches/0080-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch
+++ b/patches/0080-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch
@@ -1,7 +1,7 @@
-From b3bfef9365aed29f3f8ca208eff2862b66038c66 Mon Sep 17 00:00:00 2001
+From 1c1dc1ab70f5ce23bcc151ed9056181fd41cb48b Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 8 Sep 2020 11:17:27 +0800
-Subject: [PATCH 1/6] qsv: add ${includedir}/mfx to the search path for old
+Subject: [PATCH] qsv: add ${includedir}/mfx to the search path for old
  versions of libmfx
 
 ${includedir}/mfx has been added to Cflags in libmfx.pc for the current
@@ -26,8 +26,6 @@ to CFLAGS) so that the build can find the headers
  libavcodec/qsv_internal.h        |  2 +-
  libavcodec/qsvdec.c              |  2 +-
  libavcodec/qsvdec.h              |  2 +-
- libavcodec/qsvdec_h2645.c        |  2 +-
- libavcodec/qsvdec_other.c        |  2 +-
  libavcodec/qsvenc.c              |  2 +-
  libavcodec/qsvenc.h              |  2 +-
  libavcodec/qsvenc_h264.c         |  2 +-
@@ -41,10 +39,10 @@ to CFLAGS) so that the build can find the headers
  libavutil/hwcontext_opencl.c     |  2 +-
  libavutil/hwcontext_qsv.c        |  2 +-
  libavutil/hwcontext_qsv.h        |  2 +-
- 22 files changed, 36 insertions(+), 27 deletions(-)
+ 20 files changed, 34 insertions(+), 25 deletions(-)
 
 diff --git a/configure b/configure
-index 6c2b7d217a..271b56dd47 100755
+index 9a42e8e1a2..fce28e24b4 100755
 --- a/configure
 +++ b/configure
 @@ -1458,6 +1458,14 @@ check_pkg_config(){
@@ -62,7 +60,7 @@ index 6c2b7d217a..271b56dd47 100755
  test_exec(){
      test_ld "cc" "$@" && { enabled cross_compile || $TMPE >> $logfile 2>&1; }
  }
-@@ -6370,10 +6378,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6376,10 +6384,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
@@ -143,7 +141,7 @@ index 5d276b091c..4f0f1dae87 100644
  #include "libavutil/frame.h"
  
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index c666aaeb52..e49f08a41e 100644
+index d10f90a0db..738e27be61 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -24,7 +24,7 @@
@@ -168,34 +166,8 @@ index f3b7344cba..3f3882754f 100644
  
  #include "libavutil/fifo.h"
  #include "libavutil/frame.h"
-diff --git a/libavcodec/qsvdec_h2645.c b/libavcodec/qsvdec_h2645.c
-index 02c41883b6..ad0fcae3e5 100644
---- a/libavcodec/qsvdec_h2645.c
-+++ b/libavcodec/qsvdec_h2645.c
-@@ -25,7 +25,7 @@
- #include <stdint.h>
- #include <string.h>
- 
--#include <mfx/mfxvideo.h>
-+#include <mfxvideo.h>
- 
- #include "libavutil/common.h"
- #include "libavutil/fifo.h"
-diff --git a/libavcodec/qsvdec_other.c b/libavcodec/qsvdec_other.c
-index 2775e07955..80bc79e9fa 100644
---- a/libavcodec/qsvdec_other.c
-+++ b/libavcodec/qsvdec_other.c
-@@ -24,7 +24,7 @@
- #include <stdint.h>
- #include <string.h>
- 
--#include <mfx/mfxvideo.h>
-+#include <mfxvideo.h>
- 
- #include "libavutil/common.h"
- #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index ebab5486e4..8fc9efc6c5 100644
+index 851dca92b1..95a8921ce3 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -23,7 +23,7 @@
@@ -221,7 +193,7 @@ index 6d305f87dd..4c18f58a8b 100644
  #include "libavutil/avutil.h"
  #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 17be0a7f14..28020b367d 100644
+index ddafc45ec3..25b87a0506 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -24,7 +24,7 @@
@@ -234,7 +206,7 @@ index 17be0a7f14..28020b367d 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index 987b4b4689..bdaa87272e 100644
+index 663f21439f..af1c715e9d 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -22,7 +22,7 @@
@@ -286,7 +258,7 @@ index ce44c09397..159f5cb983 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index c2bcce7548..cd3655b7a3 100644
+index b4baeedf9e..8861713d17 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -24,7 +24,7 @@
@@ -299,7 +271,7 @@ index c2bcce7548..cd3655b7a3 100644
  #include "avfilter.h"
  
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index f7f9d916db..7b61b72599 100644
+index c27a5b037d..ffadc99763 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -21,7 +21,7 @@
@@ -312,7 +284,7 @@ index f7f9d916db..7b61b72599 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 9eb59325c3..3ddc3acfe0 100644
+index 3e9b116f33..aef35877ec 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -21,7 +21,7 @@
@@ -364,5 +336,5 @@ index b98d611cfc..42e34d0dda 100644
  /**
   * @file
 -- 
-2.25.1
+2.17.1
 

--- a/patches/0082-qsv-libmfx-no-longer-supports-audio-since-version-2..patch
+++ b/patches/0082-qsv-libmfx-no-longer-supports-audio-since-version-2..patch
@@ -1,12 +1,13 @@
-From 4ba54b81b814c5197c5fc1ac0a0ad9f417340f3e Mon Sep 17 00:00:00 2001
+From ebe2a8073c4c3ee5787beb06dea6e2e52e055650 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 18 Aug 2020 15:30:32 +0800
-Subject: [PATCH 3/6] qsv: libmfx no longer supports audio since version 2.0
+Subject: [PATCH] qsv: libmfx no longer supports audio since version 2.0
  (oneVPL)
 
 ---
- libavcodec/qsv.c | 4 ++++
- 1 file changed, 4 insertions(+)
+ libavcodec/qsv.c     | 4 ++++
+ libavfilter/qsvvpp.c | 4 ++++
+ 2 files changed, 8 insertions(+)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
 index b5c11af910..fa7c166016 100644
@@ -33,6 +34,31 @@ index b5c11af910..fa7c166016 100644
  };
  
  int ff_qsv_map_error(mfxStatus mfx_err, const char **desc)
+diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
+index ce1261eda4..3a880b6927 100644
+--- a/libavfilter/qsvvpp.c
++++ b/libavfilter/qsvvpp.c
+@@ -126,8 +126,10 @@ static const struct {
+     { MFX_ERR_INVALID_VIDEO_PARAM,      AVERROR(EINVAL), "invalid video parameters"             },
+     { MFX_ERR_UNDEFINED_BEHAVIOR,       AVERROR_BUG,     "undefined behavior"                   },
+     { MFX_ERR_DEVICE_FAILED,            AVERROR(EIO),    "device failed"                        },
++#if !QSV_VERSION_ATLEAST(2, 0)
+     { MFX_ERR_INCOMPATIBLE_AUDIO_PARAM, AVERROR(EINVAL), "incompatible audio parameters"        },
+     { MFX_ERR_INVALID_AUDIO_PARAM,      AVERROR(EINVAL), "invalid audio parameters"             },
++#endif
+ 
+     { MFX_WRN_IN_EXECUTION,             0,               "operation in execution"               },
+     { MFX_WRN_DEVICE_BUSY,              0,               "device busy"                          },
+@@ -137,7 +139,9 @@ static const struct {
+     { MFX_WRN_VALUE_NOT_CHANGED,        0,               "value is saturated"                   },
+     { MFX_WRN_OUT_OF_RANGE,             0,               "value out of range"                   },
+     { MFX_WRN_FILTER_SKIPPED,           0,               "filter skipped"                       },
++#if !QSV_VERSION_ATLEAST(2, 0)
+     { MFX_WRN_INCOMPATIBLE_AUDIO_PARAM, 0,               "incompatible audio parameters"        },
++#endif
+ };
+ 
+ static int qsv_map_error(mfxStatus mfx_err, const char **desc)
 -- 
-2.25.1
+2.17.1
 

--- a/patches/0085-qsv-libmfx-no-longer-supports-OPAQUE-memory-since-ve.patch
+++ b/patches/0085-qsv-libmfx-no-longer-supports-OPAQUE-memory-since-ve.patch
@@ -1,8 +1,8 @@
-From 58fcc347294bb6389ab84b61baa86121ecacad71 Mon Sep 17 00:00:00 2001
+From 644e308bf52738e6b38b3f63a266adde7a9c432c Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 09:43:12 +0800
-Subject: [PATCH 6/6] qsv: libmfx no longer supports OPAQUE memory since
- version 2.0 (oneVPL)
+Subject: [PATCH] qsv: libmfx no longer supports OPAQUE memory since version
+ 2.0 (oneVPL)
 
 ---
  libavcodec/qsv.c                 |  4 ++
@@ -11,12 +11,12 @@ Subject: [PATCH 6/6] qsv: libmfx no longer supports OPAQUE memory since
  libavcodec/qsvdec.c              |  9 ++++
  libavcodec/qsvenc.c              | 21 +++++++++
  libavcodec/qsvenc.h              |  2 +
- libavfilter/qsvvpp.c             | 24 ++++++++++-
+ libavfilter/qsvvpp.c             | 28 +++++++++++-
  libavfilter/qsvvpp.h             |  2 +
  libavfilter/vf_deinterlace_qsv.c | 56 +++++++++++++-----------
  libavfilter/vf_scale_qsv.c       | 74 ++++++++++++++++++--------------
  libavutil/hwcontext_qsv.c        | 56 +++++++++++++++++-------
- 11 files changed, 178 insertions(+), 74 deletions(-)
+ 11 files changed, 182 insertions(+), 74 deletions(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
 index fa7c166016..1df0f7c7d2 100644
@@ -64,10 +64,10 @@ index 4f0f1dae87..cf7f688f60 100644
      AVBufferRef *hw_frames_ref;
      mfxHDLPair handle_pair;
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index e49f08a41e..67129f30fb 100644
+index 738e27be61..b803bb6b4f 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -119,7 +119,11 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+@@ -120,7 +120,11 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
  
          ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
                                           &q->frames_ctx, q->load_plugins,
@@ -79,7 +79,7 @@ index e49f08a41e..67129f30fb 100644
                                           q->gpu_copy);
          if (ret < 0) {
              av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
-@@ -201,10 +205,15 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
+@@ -202,10 +206,15 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
          AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
  
          if (!iopattern) {
@@ -96,10 +96,10 @@ index e49f08a41e..67129f30fb 100644
      }
  
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 34fe552acf..4e22ec82f2 100644
+index 6520e500ef..5df75232b7 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -1028,6 +1028,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1015,6 +1015,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
      return 0;
  }
  
@@ -107,7 +107,7 @@ index 34fe552acf..4e22ec82f2 100644
  static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
  {
      AVQSVContext *qsv = avctx->hwaccel_context;
-@@ -1064,6 +1065,7 @@ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1051,6 +1052,7 @@ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
  
      return 0;
  }
@@ -115,7 +115,7 @@ index 34fe552acf..4e22ec82f2 100644
  
  static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
  {
-@@ -1079,7 +1081,11 @@ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1066,7 +1068,11 @@ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
  
          ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
                                           &q->frames_ctx, q->load_plugins,
@@ -127,7 +127,7 @@ index 34fe552acf..4e22ec82f2 100644
                                           MFX_GPUCOPY_OFF);
          if (ret < 0) {
              av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
-@@ -1141,11 +1147,17 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1128,11 +1134,17 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
          AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
  
          if (!iopattern) {
@@ -145,7 +145,7 @@ index 34fe552acf..4e22ec82f2 100644
          }
      }
  
-@@ -1218,9 +1230,16 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1206,9 +1218,16 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
                                    "Error querying (IOSurf) the encoding parameters");
  
      if (opaque_alloc) {
@@ -162,7 +162,7 @@ index 34fe552acf..4e22ec82f2 100644
      }
  
      ret = MFXVideoENCODE_Init(q->session, &q->param);
-@@ -1667,8 +1686,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1655,8 +1674,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
      av_fifo_free(q->async_fifo);
      q->async_fifo = NULL;
  
@@ -190,7 +190,7 @@ index 7874679a37..9cfbb3fe12 100644
      mfxExtBuffer  *extparam_internal[2 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + (QSV_HAVE_MF * 2)];
      int         nb_extparam_internal;
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index c89d4180d0..1b24a4ef81 100644
+index 3a880b6927..8b3a1bcc15 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -34,7 +34,9 @@
@@ -216,7 +216,22 @@ index c89d4180d0..1b24a4ef81 100644
  };
  
  static const AVRational default_tb = { 1, 90000 };
-@@ -450,9 +454,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -77,10 +81,14 @@ static const struct {
+ } qsv_iopatterns[] = {
+     {MFX_IOPATTERN_IN_VIDEO_MEMORY,     "input is video memory surface"         },
+     {MFX_IOPATTERN_IN_SYSTEM_MEMORY,    "input is system memory surface"        },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_IN_OPAQUE_MEMORY,    "input is opaque memory surface"        },
++#endif
+     {MFX_IOPATTERN_OUT_VIDEO_MEMORY,    "output is video memory surface"        },
+     {MFX_IOPATTERN_OUT_SYSTEM_MEMORY,   "output is system memory surface"       },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_OUT_OPAQUE_MEMORY,   "output is opaque memory surface"       },
++#endif
+ };
+ 
+ int ff_qsvvpp_print_iopattern(void *log_ctx, int mfx_iopattern,
+@@ -558,9 +566,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
          if (!out_frames_ref)
              return AVERROR(ENOMEM);
  
@@ -230,7 +245,7 @@ index c89d4180d0..1b24a4ef81 100644
  
          out_frames_ctx   = (AVHWFramesContext *)out_frames_ref->data;
          out_frames_hwctx = out_frames_ctx->hwctx;
-@@ -534,6 +542,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -647,6 +659,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
              return AVERROR_UNKNOWN;
      }
  
@@ -238,7 +253,7 @@ index c89d4180d0..1b24a4ef81 100644
      if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
          s->opaque_alloc.In.Surfaces   = s->surface_ptrs_in;
          s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs_in;
-@@ -545,7 +554,9 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -658,7 +671,9 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
  
          s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
          s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
@@ -249,7 +264,7 @@ index c89d4180d0..1b24a4ef81 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = s,
              .Alloc  = frame_alloc,
-@@ -617,6 +628,7 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -730,6 +745,7 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          goto failed;
      }
  
@@ -257,7 +272,7 @@ index c89d4180d0..1b24a4ef81 100644
      if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
          s->nb_ext_buffers = param->num_ext_buf + 1;
          s->ext_buffers = av_mallocz_array(s->nb_ext_buffers, sizeof(*s->ext_buffers));
-@@ -634,6 +646,10 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -747,6 +763,10 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          s->vpp_param.NumExtParam = param->num_ext_buf;
          s->vpp_param.ExtParam    = param->ext_buf;
      }
@@ -268,7 +283,7 @@ index c89d4180d0..1b24a4ef81 100644
  
      s->vpp_param.AsyncDepth = 1;
  
-@@ -641,15 +657,19 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -754,15 +774,19 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_SYSTEM_MEMORY;
      else if (IS_VIDEO_MEMORY(s->in_mem_mode))
          s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_VIDEO_MEMORY;
@@ -286,9 +301,9 @@ index c89d4180d0..1b24a4ef81 100644
          s->vpp_param.IOPattern |= MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
 +#endif
  
-     ret = MFXVideoVPP_Init(s->session, &s->vpp_param);
-     if (ret < 0) {
-@@ -683,7 +703,9 @@ int ff_qsvvpp_free(QSVVPPContext **vpp)
+     /* Print input memory mode */
+     ff_qsvvpp_print_iopattern(avctx, s->vpp_param.IOPattern & 0x0F, "VPP");
+@@ -801,7 +825,9 @@ int ff_qsvvpp_free(QSVVPPContext **vpp)
      clear_frame_list(&s->out_frame_list);
      av_freep(&s->surface_ptrs_in);
      av_freep(&s->surface_ptrs_out);
@@ -299,7 +314,7 @@ index c89d4180d0..1b24a4ef81 100644
      av_freep(vpp);
  
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index cd3655b7a3..753d4fa767 100644
+index 8861713d17..ad738dc9b2 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -39,6 +39,8 @@
@@ -312,7 +327,7 @@ index cd3655b7a3..753d4fa767 100644
  
  typedef struct QSVVPPCrop {
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index 7b61b72599..23d9eb32d8 100644
+index ffadc99763..d91dbf1b0b 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -70,7 +70,9 @@ typedef struct QSVDeintContext {
@@ -346,7 +361,7 @@ index 7b61b72599..23d9eb32d8 100644
      /* extract the properties of the "master" session given to us */
      ret = MFXQueryIMPL(device_hwctx->session, &impl);
      if (ret == MFX_ERR_NONE)
-@@ -241,28 +244,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -246,28 +249,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->deint_conf;
  
@@ -376,7 +391,7 @@ index 7b61b72599..23d9eb32d8 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -286,6 +268,30 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -291,6 +273,30 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -408,7 +423,7 @@ index 7b61b72599..23d9eb32d8 100644
      par.ExtParam    = s->ext_buffers;
      par.NumExtParam = s->num_ext_buffers;
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 3ddc3acfe0..310972feed 100644
+index aef35877ec..5cf9202eb4 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -90,7 +90,9 @@ typedef struct QSVScaleContext {
@@ -440,7 +455,7 @@ index 3ddc3acfe0..310972feed 100644
      s->num_ext_buf = 0;
  
      /* extract the properties of the "master" session given to us */
-@@ -345,38 +350,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -348,38 +353,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      memset(&par, 0, sizeof(par));
  
@@ -480,7 +495,7 @@ index 3ddc3acfe0..310972feed 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -408,6 +382,40 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -411,6 +385,40 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -675,5 +690,5 @@ index 011a76dfa9..42363b85be 100644
      s->session_download = NULL;
      s->session_upload   = NULL;
 -- 
-2.25.1
+2.17.1
 


### PR DESCRIPTION
Submodule ffmpeg df4e2b923c..911ba8417e

patches/0046-ffmpeg-Add-DX11-support-for-QSV.patch
patches/0080-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch
patches/0082-qsv-libmfx-no-longer-supports-audio-since-version-2..patch
patches/0085-qsv-libmfx-no-longer-supports-OPAQUE-memory-since-ve.patch

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>