### PR TITLE
Update patches and submodule

### DIFF
--- a/patches/0026-ffmpeg-Add-DX11-support-for-QSV.patch
+++ b/patches/0026-ffmpeg-Add-DX11-support-for-QSV.patch
@@ -1,7 +1,7 @@
-From 86df666007fe6f0d1f91ca6feddaaae485064f05 Mon Sep 17 00:00:00 2001
+From 797bb409bfc360f8683e1dfba1a6046c0f7a3837 Mon Sep 17 00:00:00 2001
 From: "Galin, Artem" <artem.galin@intel.com>
 Date: Tue, 26 May 2020 14:28:46 +0800
-Subject: [PATCH 26/69] ffmpeg: Add DX11 support for QSV
+Subject: [PATCH 26/72] ffmpeg: Add DX11 support for QSV
 
 ---
  fftools/ffmpeg_opt.c             |   6 +-
@@ -16,10 +16,10 @@ Subject: [PATCH 26/69] ffmpeg: Add DX11 support for QSV
  9 files changed, 509 insertions(+), 161 deletions(-)
 
 diff --git a/fftools/ffmpeg_opt.c b/fftools/ffmpeg_opt.c
-index bf2eb26246..60111bee55 100644
+index 85feeb89f2..de72824259 100644
 --- a/fftools/ffmpeg_opt.c
 +++ b/fftools/ffmpeg_opt.c
-@@ -579,7 +579,11 @@ static int opt_init_hw_device(void *optctx, const char *opt, const char *arg)
+@@ -580,7 +580,11 @@ static int opt_init_hw_device(void *optctx, const char *opt, const char *arg)
          printf("\n");
          exit_program(0);
      } else {
@@ -431,7 +431,7 @@ index 2ac2373955..3e9b116f33 100644
      }
  
 diff --git a/libavutil/hwcontext_d3d11va.c b/libavutil/hwcontext_d3d11va.c
-index c8ae58f908..2d8406427a 100644
+index 2a3549ebd8..1e6a063b6e 100644
 --- a/libavutil/hwcontext_d3d11va.c
 +++ b/libavutil/hwcontext_d3d11va.c
 @@ -72,8 +72,8 @@ static av_cold void load_functions(void)
@@ -485,8 +485,8 @@ index c8ae58f908..2d8406427a 100644
 +    return wrap_texture_buf(ctx, tex, 0);
  }
  
- static AVBufferRef *d3d11va_pool_alloc(void *opaque, int size)
-@@ -220,7 +228,7 @@ static AVBufferRef *d3d11va_pool_alloc(void *opaque, int size)
+ static AVBufferRef *d3d11va_pool_alloc(void *opaque, buffer_size_t size)
+@@ -220,7 +228,7 @@ static AVBufferRef *d3d11va_pool_alloc(void *opaque, buffer_size_t size)
      }
  
      ID3D11Texture2D_AddRef(hwctx->texture);
@@ -597,7 +597,7 @@ index 9f91e9b1b6..dd782bcc12 100644
  
  #endif /* AVUTIL_HWCONTEXT_D3D11VA_H */
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 68681cc88e..8285ce03b5 100644
+index 3a642ec554..c810abe5ed 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -27,9 +27,13 @@
@@ -752,7 +752,7 @@ index 68681cc88e..8285ce03b5 100644
      av_buffer_unref(&s->child_frames_ref);
  }
  
-@@ -208,6 +241,8 @@ static AVBufferRef *qsv_pool_alloc(void *opaque, int size)
+@@ -208,6 +241,8 @@ static AVBufferRef *qsv_pool_alloc(void *opaque, buffer_size_t size)
  
      if (s->nb_surfaces_used < hwctx->nb_surfaces) {
          s->nb_surfaces_used++;

--- a/patches/0057-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
+++ b/patches/0057-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
@@ -1,7 +1,7 @@
-From 23fb52b6164d2b399f7b5c1f13dda21d5bc7e980 Mon Sep 17 00:00:00 2001
+From 5d69359eb95a32c5272f7053fea392b042e2a5dd Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 18 Jan 2021 16:22:29 +0800
-Subject: [PATCH 57/69] libavcodec/qsvdec.c: extract frame packing arrangement
+Subject: [PATCH 57/72] libavcodec/qsvdec.c: extract frame packing arrangement
  data
 
 Use h264_sei to parse SEI data got from MediaSDK. Extract frame
@@ -11,9 +11,8 @@ side data for decoded frame.
 Sigend-off-by: Wenbin Chen <wenbin.chen@intel.com>
 ---
  libavcodec/qsv_internal.h |   2 +
- libavcodec/qsvdec.c       | 149 ++++++++++++++++++++++++++++++++++++++
- libavcodec/qsvdec.h       |   6 ++
- 3 files changed, 157 insertions(+)
+ libavcodec/qsvdec.c       | 157 ++++++++++++++++++++++++++++++++++++++
+ 2 files changed, 159 insertions(+)
 
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
 index 5d276b091c..e674464c6c 100644
@@ -29,10 +28,10 @@ index 5d276b091c..e674464c6c 100644
      (MFX_VERSION_MAJOR > (MAJOR) ||         \
       MFX_VERSION_MAJOR == (MAJOR) && MFX_VERSION_MINOR >= (MINOR))
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index d10f90a0db..5cb49cfb4a 100644
+index 5f2e641373..30a4fbd84d 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -36,10 +36,12 @@
+@@ -38,12 +38,15 @@
  #include "libavutil/pixfmt.h"
  #include "libavutil/time.h"
  #include "libavutil/imgutils.h"
@@ -41,11 +40,28 @@ index d10f90a0db..5cb49cfb4a 100644
  #include "avcodec.h"
  #include "internal.h"
  #include "decode.h"
+ #include "hwconfig.h"
 +#include "get_bits.h"
  #include "qsv.h"
++#include "h264_sei.h"
  #include "qsv_internal.h"
- #include "qsvdec.h"
-@@ -398,6 +400,147 @@ static QSVFrame *find_frame(QSVContext *q, mfxFrameSurface1 *surf)
+ 
+ typedef struct QSVContext {
+@@ -80,8 +83,13 @@ typedef struct QSVContext {
+ 
+     char *load_plugins;
+ 
++    mfxPayload payload;
++
+     mfxExtBuffer **ext_buffers;
+     int         nb_ext_buffers;
++
++    H264SEIContext sei;
++    H264ParamSets ps;
+ } QSVContext;
+ 
+ static const AVCodecHWConfigInternal *const qsv_hw_configs[] = {
+@@ -441,6 +449,147 @@ static QSVFrame *find_frame(QSVContext *q, mfxFrameSurface1 *surf)
      return NULL;
  }
  
@@ -192,8 +208,8 @@ index d10f90a0db..5cb49cfb4a 100644
 +
  static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
                        AVFrame *frame, int *got_frame,
-                       AVPacket *avpkt)
-@@ -501,6 +644,10 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
+                       const AVPacket *avpkt)
+@@ -544,6 +693,10 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
  
          outsurf = &out_frame->surface;
  
@@ -204,41 +220,17 @@ index d10f90a0db..5cb49cfb4a 100644
  #if FF_API_PKT_PTS
  FF_DISABLE_DEPRECATION_WARNINGS
          frame->pkt_pts = outsurf->Data.TimeStamp;
-@@ -564,6 +711,8 @@ int ff_qsv_decode_close(QSVContext *q)
+@@ -606,6 +759,10 @@ static void qsv_decode_close_qsvcontext(QSVContext *q)
+     av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
      av_buffer_unref(&q->frames_ctx.mids_buf);
      av_buffer_pool_uninit(&q->pool);
- 
++
 +    av_freep(&q->payload.Data);
 +
-     return 0;
++    return 0;
  }
  
-diff --git a/libavcodec/qsvdec.h b/libavcodec/qsvdec.h
-index f3b7344cba..282943b00c 100644
---- a/libavcodec/qsvdec.h
-+++ b/libavcodec/qsvdec.h
-@@ -34,6 +34,7 @@
- 
- #include "avcodec.h"
- #include "hwconfig.h"
-+#include "h264_sei.h"
- #include "qsv_internal.h"
- 
- typedef struct QSVContext {
-@@ -70,8 +71,13 @@ typedef struct QSVContext {
- 
-     char *load_plugins;
- 
-+    mfxPayload payload;
-+
-     mfxExtBuffer **ext_buffers;
-     int         nb_ext_buffers;
-+
-+    H264SEIContext sei;
-+    H264ParamSets ps;
- } QSVContext;
- 
- extern const AVCodecHWConfigInternal *const ff_qsv_hw_configs[];
+ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
 -- 
 2.17.1
 

--- a/patches/0062-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
+++ b/patches/0062-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
@@ -1,7 +1,7 @@
-From 712fd1352d4fa3845ae31c30e0294757c2c8e5e4 Mon Sep 17 00:00:00 2001
+From b32cc7002b0458e99198c7043d226f8c012130b7 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Tue, 26 Jan 2021 09:55:59 +0800
-Subject: [PATCH 62/69] libavcodec/qsvdec: using suggested num to set
+Subject: [PATCH 62/72] libavcodec/qsvdec: using suggested num to set
  init_pool_size
 
 The init_pool_size is set to be 64 and it is too many.
@@ -52,18 +52,18 @@ index 960c88b69d..3862dc1e7d 100644
  
      ret = av_hwframe_ctx_init(ist->hw_frames_ctx);
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 5cb49cfb4a..fba7d9cee6 100644
+index 30a4fbd84d..1de97217cf 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -720,6 +720,7 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
-                         AVFrame *frame, int *got_frame, AVPacket *pkt)
+@@ -769,6 +769,7 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+                             AVFrame *frame, int *got_frame, const AVPacket *pkt)
  {
      int ret;
 +    int first_init;
      mfxVideoParam param = { 0 };
      enum AVPixelFormat pix_fmt = AV_PIX_FMT_NV12;
  
-@@ -738,12 +739,20 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+@@ -787,12 +788,20 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
      if (!avctx->coded_height)
          avctx->coded_height = 720;
  
@@ -85,7 +85,7 @@ index 5cb49cfb4a..fba7d9cee6 100644
  
          if (q->buffered_count) {
              q->reinit_flag = 1;
-@@ -758,6 +767,23 @@ int ff_qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+@@ -807,6 +816,23 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
          avctx->coded_width  = param.mfx.FrameInfo.Width;
          avctx->coded_height = param.mfx.FrameInfo.Height;
  

--- a/patches/0065-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch
+++ b/patches/0065-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch
@@ -1,7 +1,7 @@
-From 40ee811089a698870990faa6723412b74db813fa Mon Sep 17 00:00:00 2001
+From aebdc9683a171b86873581d66e3d3e19be8cd047 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 8 Sep 2020 11:17:27 +0800
-Subject: [PATCH 65/71] qsv: add ${includedir}/mfx to the search path for old
+Subject: [PATCH 65/72] qsv: add ${includedir}/mfx to the search path for old
  versions of libmfx
 
 ${includedir}/mfx has been added to Cflags in libmfx.pc for the current
@@ -27,7 +27,6 @@ This is in preparation for oneVPL support
  libavcodec/qsv.h                 |  2 +-
  libavcodec/qsv_internal.h        |  2 +-
  libavcodec/qsvdec.c              |  2 +-
- libavcodec/qsvdec.h              |  2 +-
  libavcodec/qsvenc.c              |  2 +-
  libavcodec/qsvenc.h              |  2 +-
  libavcodec/qsvenc_h264.c         |  2 +-
@@ -41,10 +40,10 @@ This is in preparation for oneVPL support
  libavutil/hwcontext_opencl.c     |  2 +-
  libavutil/hwcontext_qsv.c        |  2 +-
  libavutil/hwcontext_qsv.h        |  2 +-
- 20 files changed, 33 insertions(+), 27 deletions(-)
+ 19 files changed, 32 insertions(+), 26 deletions(-)
 
 diff --git a/configure b/configure
-index 45427fc462..46a790707e 100755
+index 3b74421dbe..1beaa0bf46 100755
 --- a/configure
 +++ b/configure
 @@ -6376,12 +6376,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
@@ -137,10 +136,10 @@ index 707e5d6be0..dbef6f8bcd 100644
  #include "libavutil/frame.h"
  
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 23494c217d..3477f74b0c 100644
+index d574ab4a7c..ae46e8e1d0 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -24,7 +24,7 @@
+@@ -25,7 +25,7 @@
  #include <string.h>
  #include <sys/types.h>
  
@@ -148,20 +147,7 @@ index 23494c217d..3477f74b0c 100644
 +#include <mfxvideo.h>
  
  #include "libavutil/common.h"
- #include "libavutil/hwcontext.h"
-diff --git a/libavcodec/qsvdec.h b/libavcodec/qsvdec.h
-index 282943b00c..081213df7e 100644
---- a/libavcodec/qsvdec.h
-+++ b/libavcodec/qsvdec.h
-@@ -26,7 +26,7 @@
- #include <stdint.h>
- #include <sys/types.h>
- 
--#include <mfx/mfxvideo.h>
-+#include <mfxvideo.h>
- 
  #include "libavutil/fifo.h"
- #include "libavutil/frame.h"
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
 index 3b63d194e8..138f2cab6e 100644
 --- a/libavcodec/qsvenc.c
@@ -293,7 +279,7 @@ index 3e9b116f33..aef35877ec 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavutil/hwcontext_opencl.c b/libavutil/hwcontext_opencl.c
-index cd8638abbb..029be4034a 100644
+index ee814602b2..17e5ec9f7d 100644
 --- a/libavutil/hwcontext_opencl.c
 +++ b/libavutil/hwcontext_opencl.c
 @@ -47,7 +47,7 @@
@@ -306,7 +292,7 @@ index cd8638abbb..029be4034a 100644
  #include <va/va.h>
  #include <CL/cl_va_api_media_sharing_intel.h>
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 34ff5e5572..011a76dfa9 100644
+index a4b9e0569b..9e1555a43e 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -19,7 +19,7 @@


### PR DESCRIPTION
patches/0026-ffmpeg-Add-DX11-support-for-QSV.patch
patches/0057-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
patches/0062-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
patches/0065-qsv-add-includedir-mfx-to-the-search-path-for-old-ve.patch

Submodule ffmpeg 74b5564fb5..f4f5da0d91

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>