### PR TITLE
rebase patch 12 and update submodule

### DIFF
--- a/patches/0012-lavc-libvpxenc-add-dynamic-resolution-encode-support.patch
+++ b/patches/0012-lavc-libvpxenc-add-dynamic-resolution-encode-support.patch
@@ -1,8 +1,8 @@
-From 75f524db1ba32e2f48742c5b55550c4270b438ec Mon Sep 17 00:00:00 2001
+From bba67694eeaa325ff7441f502fd551c0791939a5 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Wed, 31 Jul 2019 12:18:21 +0800
-Subject: [PATCH 12/69] lavc/libvpxenc: add dynamic resolution encode support
- for libvpx
+Subject: [PATCH] lavc/libvpxenc: add dynamic resolution encode support for
+ libvpx
 
 According to spec, libvpx should support dynamic resolution changes.
 
@@ -21,10 +21,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 32 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/libvpxenc.c b/libavcodec/libvpxenc.c
-index 284cb9a108..ecdc3a789e 100644
+index 3f36943c12ca..a1a40de23380 100644
 --- a/libavcodec/libvpxenc.c
 +++ b/libavcodec/libvpxenc.c
-@@ -1543,6 +1543,34 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
+@@ -1580,6 +1580,34 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
      vpx_svc_layer_id_t layer_id;
      int layer_id_valid = 0;
  
@@ -59,7 +59,7 @@ index 284cb9a108..ecdc3a789e 100644
      if (frame) {
          const AVFrameSideData *sd = av_frame_get_side_data(frame, AV_FRAME_DATA_REGIONS_OF_INTEREST);
          rawimg                      = &ctx->rawimg;
-@@ -1552,6 +1580,8 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
+@@ -1589,6 +1617,8 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
          rawimg->stride[VPX_PLANE_Y] = frame->linesize[0];
          rawimg->stride[VPX_PLANE_U] = frame->linesize[1];
          rawimg->stride[VPX_PLANE_V] = frame->linesize[2];
@@ -68,24 +68,24 @@ index 284cb9a108..ecdc3a789e 100644
          if (ctx->is_alpha) {
              rawimg_alpha = &ctx->rawimg_alpha;
              res = realloc_alpha_uv(avctx, frame->width, frame->height);
-@@ -1835,7 +1865,7 @@ AVCodec ff_libvpx_vp8_encoder = {
+@@ -1870,7 +1900,7 @@ AVCodec ff_libvpx_vp8_encoder = {
      .init           = vp8_init,
      .encode2        = vpx_encode,
      .close          = vpx_free,
--    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
-+    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS | AV_CODEC_CAP_PARAM_CHANGE,
+-    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS,
++    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_PARAM_CHANGE,
+     .caps_internal  = FF_CODEC_CAP_AUTO_THREADS,
      .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_YUV420P, AV_PIX_FMT_YUVA420P, AV_PIX_FMT_NONE },
      .priv_class     = &class_vp8,
-     .defaults       = defaults,
-@@ -1865,7 +1895,7 @@ AVCodec ff_libvpx_vp9_encoder = {
+@@ -1901,7 +1931,7 @@ AVCodec ff_libvpx_vp9_encoder = {
      .init           = vp9_init,
      .encode2        = vpx_encode,
      .close          = vpx_free,
--    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS,
-+    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_AUTO_THREADS | AV_CODEC_CAP_PARAM_CHANGE,
+-    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS,
++    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_OTHER_THREADS | AV_CODEC_CAP_PARAM_CHANGE,
+     .caps_internal  = FF_CODEC_CAP_AUTO_THREADS,
      .profiles       = NULL_IF_CONFIG_SMALL(ff_vp9_profiles),
      .priv_class     = &class_vp9,
-     .defaults       = defaults,
 -- 
-2.17.1
+2.25.4
 


### PR DESCRIPTION
Fix patches/0012-lavc-libvpxenc-add-dynamic-resolution-encode-support.patch
conflict with updated remote submodule.

Submodule ffmpeg 63344337f945..30a69b162581

Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>