### PR TITLE
WIP:vaapi: use xyuv instead of ayuv

### DIFF
--- a/patches/0086-vaapi-use-new-fourcc-code.patch
+++ b/patches/0086-vaapi-use-new-fourcc-code.patch
@@ -1,0 +1,59 @@
+From e341a75e470444976d67e81d43bcd5f47270f171 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Sat, 20 Feb 2021 16:40:39 +0800
+Subject: [PATCH 86/86] vaapi: use new fourcc code
+
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ libavcodec/vaapi_decode.c   | 8 ++++++++
+ libavutil/hwcontext_vaapi.c | 8 ++++++++
+ 2 files changed, 16 insertions(+)
+
+diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
+index 8026e0411f..78b7339233 100644
+--- a/libavcodec/vaapi_decode.c
++++ b/libavcodec/vaapi_decode.c
+@@ -265,10 +265,18 @@ static const struct {
+     MAP(422V, YUV440P),
+     // 4:4:4
+     MAP(444P, YUV444P),
++#ifdef VA_FOURCC_XYUV
++    MAP(XYUV,    0YUV),
++#else
+     MAP(AYUV,    0YUV),
++#endif
+     // 4:4:4 10-bit
++#ifdef VA_FOURCC_XV30
++    MAP(XV30,    Y410),
++#else
+ #ifdef VA_FOURCC_Y410
+     MAP(Y410,    Y410),
++#endif
+ #endif
+     // 4:2:0 10-bit
+ #ifdef VA_FOURCC_P010
+diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
+index 8423edb68f..788fa6773b 100644
+--- a/libavutil/hwcontext_vaapi.c
++++ b/libavutil/hwcontext_vaapi.c
+@@ -119,9 +119,17 @@ static const VAAPIFormatDescriptor vaapi_format_map[] = {
+ #ifdef VA_FOURCC_Y210
+     MAP(Y210, YUV422_10,  Y210, 0),
+ #endif
++#ifdef VA_FOURCC_XYUV
++    MAP(XYUV, YUV444,     0YUV, 0),
++#else
+     MAP(AYUV, YUV444,     0YUV, 0),
++#endif
++#ifdef VA_FOURCC_XV30
++    MAP(XV30, YUV444_10,  Y410, 0),
++#else
+ #ifdef VA_FOURCC_Y410
+     MAP(Y410, YUV444_10,  Y410, 0),
++#endif
+ #endif
+     MAP(411P, YUV411,  YUV411P, 0),
+     MAP(422V, YUV422,  YUV440P, 0),
+-- 
+2.25.1
+


### PR DESCRIPTION
https://github.com/intel/media-driver/pull/1144 and https://github.com/intel/libva/pull/442/ are needed for testing.
