### PR TITLE
update patches/0078-configure-add-enable-libvpl-option.patch

### DIFF
--- a/patches/0078-configure-add-enable-libvpl-option.patch
+++ b/patches/0078-configure-add-enable-libvpl-option.patch
@@ -1,4 +1,4 @@
-From 1c94285eb503b947f311c19c96b755b79d76a489 Mon Sep 17 00:00:00 2001
+From 61fe559714455417ca0dc424a343970cb7ac1739 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 3 Feb 2021 14:49:46 +0800
 Subject: [PATCH 78/93] configure: add --enable-libvpl option
@@ -6,14 +6,14 @@ Subject: [PATCH 78/93] configure: add --enable-libvpl option
 This allows user to build FFmpeg against Intel's oneVPL SDK. oneVPL 2.2
 is the required minimum version when building Intel oneVPL SDK code.
 
---enable-libmfx will take effect if both libmfx and libvpl are enabled
-when running configure
+It will fail to run configure script if both libmfx and libvpl are
+enabled.
 ---
- configure | 22 ++++++++++++++++------
- 1 file changed, 16 insertions(+), 6 deletions(-)
+ configure | 25 +++++++++++++++++++------
+ 1 file changed, 19 insertions(+), 6 deletions(-)
 
 diff --git a/configure b/configure
-index 37815264cc..ae80d02639 100755
+index cbefec9850..d61feb9a17 100755
 --- a/configure
 +++ b/configure
 @@ -337,6 +337,7 @@ External library support:
@@ -24,7 +24,7 @@ index 37815264cc..ae80d02639 100755
    --enable-libnpp          enable Nvidia Performance Primitives-based code [no]
    --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
    --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
-@@ -1894,6 +1895,7 @@ HWACCEL_LIBRARY_NONFREE_LIST="
+@@ -1895,6 +1896,7 @@ HWACCEL_LIBRARY_NONFREE_LIST="
  HWACCEL_LIBRARY_LIST="
      $HWACCEL_LIBRARY_NONFREE_LIST
      libmfx
@@ -32,13 +32,22 @@ index 37815264cc..ae80d02639 100755
      mmal
      omx
      opencl
-@@ -6452,16 +6454,24 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6441,22 +6443,33 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
+ enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
+ enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
+ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
++
++if enabled libmfx && enabled libvpl; then
++   die "ERROR: can not use libmfx and libvpl together"
+ # While it may appear that require is being used as a pkg-config
+ # fallback for libmfx, it is actually being used to detect a different
+ # installation route altogether.  If libmfx is installed via the Intel
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
 -
 -enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfxvideo.h" MFXInit ||
-+if enabled libmfx; then
++elif enabled libmfx; then
 +    { check_pkg_config libmfx "libmfx < 2.0" "mfxvideo.h" MFXInit || \
  # Some old versions of libmfx have the following settings in libmfx.pc:
  #   includedir=/usr/include
@@ -54,7 +63,7 @@ index 37815264cc..ae80d02639 100755
 +         "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"
 +elif enabled libvpl; then
 +# Consider pkg-config only, libmfx is still used for --enable-vpl option
-+    check_pkg_config libmfx "vpl >= 2.2" "mfxvideo.h" MFXInit && \
++    check_pkg_config libmfx "vpl >= 2.2" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
 +        warn "build FFmpeg against oneVPL 2.2+, OPAQUE memory, multi-frame encode, user plugins\n"\
 +             "and LA_EXT rate control mode in FFmpeg QSV won't be supported." ||
 +            die "ERROR: libvpl >= 2.2 not found"


### PR DESCRIPTION
* MFXInit has been deprecated in oneVPL, let's check MFXLoad instead
MFXInit

* Die if both --enable-libmfx and --enable-libvpl are specified. 