### PR TITLE
Add patch 0094 to fix ffmpeg-vaapi vp9 8K enc issue

### DIFF
--- a/patches/0094-avcodec-vaapi_encode_vp9-fix-4k-encode-fail-issue.patch
+++ b/patches/0094-avcodec-vaapi_encode_vp9-fix-4k-encode-fail-issue.patch
@@ -1,0 +1,49 @@
+From c6501d0b48548ccaa10e3a517afc4a278ee2c285 Mon Sep 17 00:00:00 2001
+From: Zhang yuankun <yuankunx.zhang@intel.com>
+Date: Mon, 12 Apr 2021 09:47:24 +0800
+Subject: [PATCH] avcodec/vaapi_encode_vp9: fix > 4k encode fail issue
+
+This patch will fix following command:
+ffmpeg -hwaccel vaapi -hwaccel_output_format vaapi -i input.264 \
+-vf 'scale_vaapi=w=7680:h=4096' -c:v vp9_vaapi output.ivf
+
+Max width of a vp9 tile is 4096. If the source frame > 4096, we need split to multiple tiles.
+
+Signed-off-by: Zhang yuankun <yuankunx.zhang@intel.com>
+---
+ libavcodec/vaapi_encode_vp9.c | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libavcodec/vaapi_encode_vp9.c b/libavcodec/vaapi_encode_vp9.c
+index da706f140f..d705b500eb 100644
+--- a/libavcodec/vaapi_encode_vp9.c
++++ b/libavcodec/vaapi_encode_vp9.c
+@@ -31,6 +31,7 @@
+ 
+ #define VP9_MAX_QUANT 255
+ 
++#define VP9_MAX_TILE_WIDTH 4096
+ 
+ typedef struct VAAPIEncodeVP9Picture {
+     int slot;
+@@ -82,10 +83,17 @@ static int vaapi_encode_vp9_init_picture_params(AVCodecContext *avctx,
+     VAAPIEncodeVP9Picture          *hpic = pic->priv_data;
+     VAEncPictureParameterBufferVP9 *vpic = pic->codec_picture_params;
+     int i;
++    int num_tile_columns;
+ 
+     vpic->reconstructed_frame = pic->recon_surface;
+     vpic->coded_buf = pic->output_buffer;
+ 
++    // Maximum width of a tile in units of superblocks is MAX_TILE_WIDTH_B64(64)
++    // So the number of tile columns is related to the width of the picture.
++    // We set the minimum possible number for num_tile_columns as defualt value.
++    num_tile_columns = (vpic->frame_width_src + VP9_MAX_TILE_WIDTH - 1) / VP9_MAX_TILE_WIDTH;
++    vpic->log2_tile_columns = num_tile_columns == 1 ? 0 : av_log2(num_tile_columns - 1) + 1;
++
+     switch (pic->type) {
+     case PICTURE_TYPE_IDR:
+         av_assert0(pic->nb_refs == 0);
+-- 
+2.25.1
+


### PR DESCRIPTION
Add patch 0094 to fix ffmpeg-vaapi vp9 8K enc issue

Signed-off-by: Zhang Yuankun <yuankunx.zhang@intel.com>