### PR TITLE
Update submodule and 0013/0030/0033

### DIFF
--- a/patches/0013-lavf-vf_deinterlace_vaapi-flush-queued-frame-for-fie.patch
+++ b/patches/0013-lavf-vf_deinterlace_vaapi-flush-queued-frame-for-fie.patch
@@ -1,7 +1,7 @@
-From 70e9d5ce2b2a1c798e4f9b047dd1eba5fed53450 Mon Sep 17 00:00:00 2001
+From dd223f6de119a833598591231a32908de61affa7 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 2 Aug 2019 16:11:38 +0800
-Subject: [PATCH 13/82] lavf/vf_deinterlace_vaapi: flush queued frame for field
+Subject: [PATCH 13/94] lavf/vf_deinterlace_vaapi: flush queued frame for field
  in DeinterlacingBob
 
 For DeinterlacingBob mode with rate=field, the frame number of output
@@ -31,10 +31,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 38 insertions(+), 6 deletions(-)
 
 diff --git a/libavfilter/vf_deinterlace_vaapi.c b/libavfilter/vf_deinterlace_vaapi.c
-index 0e645f50f249..d685237e1ddf 100644
+index 5ec830213e..ab5c377231 100644
 --- a/libavfilter/vf_deinterlace_vaapi.c
 +++ b/libavfilter/vf_deinterlace_vaapi.c
-@@ -48,6 +48,9 @@ typedef struct DeintVAAPIContext {
+@@ -46,6 +46,9 @@ typedef struct DeintVAAPIContext {
      int                queue_count;
      AVFrame           *frame_queue[MAX_REFERENCES];
      int                extra_delay_for_timestamps;
@@ -44,7 +44,7 @@ index 0e645f50f249..d685237e1ddf 100644
  } DeintVAAPIContext;
  
  static const char *deint_vaapi_mode_name(int mode)
-@@ -190,9 +193,11 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
+@@ -188,9 +191,11 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
      void *filter_params_addr = NULL;
      int err, i, field, current_frame_index;
  
@@ -59,7 +59,7 @@ index 0e645f50f249..d685237e1ddf 100644
  
      if (ctx->queue_count < ctx->queue_depth) {
          ctx->frame_queue[ctx->queue_count++] = input_frame;
-@@ -210,6 +215,9 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
+@@ -208,6 +213,9 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
      current_frame_index = ctx->pipeline_caps.num_forward_references;
  
      input_frame = ctx->frame_queue[current_frame_index];
@@ -69,7 +69,7 @@ index 0e645f50f249..d685237e1ddf 100644
      input_surface = (VASurfaceID)(uintptr_t)input_frame->data[3];
      for (i = 0; i < ctx->pipeline_caps.num_forward_references; i++)
          forward_references[i] = (VASurfaceID)(uintptr_t)
-@@ -291,6 +299,8 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
+@@ -289,6 +297,8 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
          if (ctx->field_rate == 2) {
              if (field == 0)
                  output_frame->pts = 2 * input_frame->pts;
@@ -78,7 +78,7 @@ index 0e645f50f249..d685237e1ddf 100644
              else
                  output_frame->pts = input_frame->pts +
                      ctx->frame_queue[current_frame_index + 1]->pts;
-@@ -306,6 +316,8 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
+@@ -304,6 +314,8 @@ static int deint_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame)
              break;
      }
  
@@ -87,7 +87,7 @@ index 0e645f50f249..d685237e1ddf 100644
      return err;
  
  fail:
-@@ -315,6 +327,25 @@ fail:
+@@ -313,6 +325,25 @@ fail:
      return err;
  }
  
@@ -113,7 +113,7 @@ index 0e645f50f249..d685237e1ddf 100644
  static av_cold int deint_vaapi_init(AVFilterContext *avctx)
  {
      VAAPIVPPContext *vpp_ctx = avctx->priv;
-@@ -376,9 +407,10 @@ static const AVFilterPad deint_vaapi_inputs[] = {
+@@ -373,9 +404,10 @@ static const AVFilterPad deint_vaapi_inputs[] = {
  
  static const AVFilterPad deint_vaapi_outputs[] = {
      {
@@ -125,8 +125,8 @@ index 0e645f50f249..d685237e1ddf 100644
 +        .request_frame  = &deint_vaapi_request_frame,
 +        .config_props   = &deint_vaapi_config_output,
      },
-     { NULL }
  };
+ 
 -- 
-2.25.4
+2.25.1
 

--- a/patches/0030-avfilter-add-overlay-vaapi-filter.patch
+++ b/patches/0030-avfilter-add-overlay-vaapi-filter.patch
@@ -1,4 +1,4 @@
-From 3f731028b976c794a1457383d92de4bda02647d7 Mon Sep 17 00:00:00 2001
+From 9db21a69066230da8d849ae41c52e508af46032d Mon Sep 17 00:00:00 2001
 From: Xinpeng Sun <xinpeng.sun@intel.com>
 Date: Wed, 26 Feb 2020 13:53:34 +0800
 Subject: [PATCH 30/94] avfilter: add overlay vaapi filter
@@ -15,6 +15,7 @@ FFMPEG -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -hwaccel_output_format v
 "[0:v]hwupload[a], [1:v]format=yuv420p, hwupload[b], [a][b]overlay_vaapi, hwdownload" \
 OUTPUT
 
+Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>
 Signed-off-by: Xinpeng Sun <xinpeng.sun@intel.com>
 Signed-off-by: Zachary Zhou <zachary.zhou@intel.com>
 ---
@@ -22,12 +23,12 @@ Signed-off-by: Zachary Zhou <zachary.zhou@intel.com>
  doc/filters.texi               |  51 ++++
  libavfilter/Makefile           |   1 +
  libavfilter/allfilters.c       |   1 +
- libavfilter/vf_overlay_vaapi.c | 426 +++++++++++++++++++++++++++++++++
- 5 files changed, 482 insertions(+)
+ libavfilter/vf_overlay_vaapi.c | 424 +++++++++++++++++++++++++++++++++
+ 5 files changed, 480 insertions(+)
  create mode 100644 libavfilter/vf_overlay_vaapi.c
 
 diff --git a/configure b/configure
-index 9249254b7082..5f54edab5bec 100755
+index 9249254b70..5f54edab5b 100755
 --- a/configure
 +++ b/configure
 @@ -3623,6 +3623,7 @@ openclsrc_filter_deps="opencl"
@@ -55,7 +56,7 @@ index 9249254b7082..5f54edab5bec 100755
      check_type "va/va.h va/va_enc_jpeg.h" "VAEncPictureParameterBufferJPEG"
      check_type "va/va.h va/va_enc_vp8.h"  "VAEncPictureParameterBufferVP8"
 diff --git a/doc/filters.texi b/doc/filters.texi
-index f8d99b717128..a4067fe814ac 100644
+index c84202cf85..0bb5741085 100644
 --- a/doc/filters.texi
 +++ b/doc/filters.texi
 @@ -23973,6 +23973,57 @@ To enable compilation of these filters you need to configure FFmpeg with
@@ -117,7 +118,7 @@ index f8d99b717128..a4067fe814ac 100644
  
  Perform HDR(High Dynamic Range) to SDR(Standard Dynamic Range) conversion with tone-mapping.
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index 102ce7beff68..a4978da29523 100644
+index 102ce7beff..a4978da295 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
 @@ -356,6 +356,7 @@ OBJS-$(CONFIG_OVERLAY_CUDA_FILTER)           += vf_overlay_cuda.o framesync.o vf
@@ -129,7 +130,7 @@ index 102ce7beff68..a4978da29523 100644
  OBJS-$(CONFIG_OWDENOISE_FILTER)              += vf_owdenoise.o
  OBJS-$(CONFIG_PAD_FILTER)                    += vf_pad.o
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 73040d2824b4..8d2150739f66 100644
+index 73040d2824..8d2150739f 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
 @@ -339,6 +339,7 @@ extern const AVFilter ff_vf_oscilloscope;
@@ -142,10 +143,10 @@ index 73040d2824b4..8d2150739f66 100644
  extern const AVFilter ff_vf_owdenoise;
 diff --git a/libavfilter/vf_overlay_vaapi.c b/libavfilter/vf_overlay_vaapi.c
 new file mode 100644
-index 000000000000..249e24cd4263
+index 0000000000..e0e583525d
 --- /dev/null
 +++ b/libavfilter/vf_overlay_vaapi.c
-@@ -0,0 +1,426 @@
+@@ -0,0 +1,424 @@
 +/*
 + * This file is part of FFmpeg.
 + *
@@ -547,7 +548,6 @@ index 000000000000..249e24cd4263
 +        .type             = AVMEDIA_TYPE_VIDEO,
 +        .get_buffer.video = ff_default_get_video_buffer,
 +    },
-+    { NULL }
 +};
 +
 +static const AVFilterPad overlay_vaapi_outputs[] = {
@@ -556,7 +556,6 @@ index 000000000000..249e24cd4263
 +        .type          = AVMEDIA_TYPE_VIDEO,
 +        .config_props  = &overlay_vaapi_config_output,
 +    },
-+    { NULL }
 +};
 +
 +AVFilter ff_vf_overlay_vaapi = {
@@ -568,10 +567,10 @@ index 000000000000..249e24cd4263
 +    .uninit          = &overlay_vaapi_uninit,
 +    .query_formats   = &overlay_vaapi_query_formats,
 +    .activate        = &overlay_vaapi_activate,
-+    .inputs          = overlay_vaapi_inputs,
-+    .outputs         = overlay_vaapi_outputs,
++    FILTER_INPUTS(overlay_vaapi_inputs),
++    FILTER_OUTPUTS(overlay_vaapi_outputs),
 +    .flags_internal  = FF_FILTER_FLAG_HWFRAME_AWARE,
 +};
 -- 
-2.25.4
+2.17.1
 

--- a/patches/0033-lavc-vaapi_hevc-add-skip_frame-invalid-to-skip-inval.patch
+++ b/patches/0033-lavc-vaapi_hevc-add-skip_frame-invalid-to-skip-inval.patch
@@ -1,7 +1,7 @@
-From eb795b1f3e9d2fb33a05d2763e7aa996e4c88859 Mon Sep 17 00:00:00 2001
+From c2459c1448e84c1ad4a14706f9a65b0b60c1a958 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 14 Jul 2020 14:56:25 +0800
-Subject: [PATCH 33/85] lavc/vaapi_hevc: add -skip_frame invalid to skip
+Subject: [PATCH 33/94] lavc/vaapi_hevc: add -skip_frame invalid to skip
  invalid nalus
 
 Works in single thread mode:
@@ -21,7 +21,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  4 files changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/defs.h b/libavcodec/defs.h
-index 420a042b8ff4..25052048b4e0 100644
+index 420a042b8f..25052048b4 100644
 --- a/libavcodec/defs.h
 +++ b/libavcodec/defs.h
 @@ -47,6 +47,7 @@ enum AVDiscard{
@@ -33,10 +33,10 @@ index 420a042b8ff4..25052048b4e0 100644
      AVDISCARD_BIDIR   = 16, ///< discard all bidirectional frames
      AVDISCARD_NONINTRA= 24, ///< discard all non intra frames
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index f20136d15593..1feb41350630 100644
+index c3005876b4..fc3d0bebaa 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -567,8 +567,11 @@ static int hls_slice_header(HEVCContext *s)
+@@ -568,8 +568,11 @@ static int hls_slice_header(HEVCContext *s)
              ff_hevc_clear_refs(s);
      }
      sh->no_output_of_prior_pics_flag = 0;
@@ -49,7 +49,7 @@ index f20136d15593..1feb41350630 100644
  
      sh->pps_id = get_ue_golomb_long(gb);
      if (sh->pps_id >= HEVC_MAX_PPS_COUNT || !s->ps.pps_list[sh->pps_id]) {
-@@ -3050,6 +3053,7 @@ static int decode_nal_unit(HEVCContext *s, const H2645NAL *nal)
+@@ -3106,6 +3109,7 @@ static int decode_nal_unit(HEVCContext *s, const H2645NAL *nal)
          if (
              (s->avctx->skip_frame >= AVDISCARD_BIDIR && s->sh.slice_type == HEVC_SLICE_B) ||
              (s->avctx->skip_frame >= AVDISCARD_NONINTRA && s->sh.slice_type != HEVC_SLICE_I) ||
@@ -58,7 +58,7 @@ index f20136d15593..1feb41350630 100644
              break;
          }
 diff --git a/libavcodec/options_table.h b/libavcodec/options_table.h
-index ed428b131046..f38bb56a0e46 100644
+index ae42b65b7b..2fd6dcabf3 100644
 --- a/libavcodec/options_table.h
 +++ b/libavcodec/options_table.h
 @@ -248,6 +248,7 @@ static const AVOption avcodec_options[] = {
@@ -70,17 +70,17 @@ index ed428b131046..f38bb56a0e46 100644
  {"bidir"           , "discard all bidirectional frames",    0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_BIDIR   }, INT_MIN, INT_MAX, V|D, "avdiscard"},
  {"nokey"           , "discard all frames except keyframes", 0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_NONKEY  }, INT_MIN, INT_MAX, V|D, "avdiscard"},
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index 2ff71ca39ecd..f6e83c3c7e66 100644
+index 8c0966f026..98fbd2a7f3 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
-@@ -277,6 +277,7 @@ static int update_context_from_thread(AVCodecContext *dst, AVCodecContext *src,
- 
+@@ -278,6 +278,7 @@ static int update_context_from_thread(AVCodecContext *dst, AVCodecContext *src,
          dst->has_b_frames = src->has_b_frames;
          dst->idct_algo    = src->idct_algo;
+         dst->properties   = src->properties;
 +        dst->skip_frame   = src->skip_frame;
  
          dst->bits_per_coded_sample = src->bits_per_coded_sample;
          dst->sample_aspect_ratio   = src->sample_aspect_ratio;
 -- 
-2.25.4
+2.17.1
 


### PR DESCRIPTION
    This fixes the conflict when applying 0013, 0030 and 0033 to submodule
    b492cac
    
    Submodule ffmpeg d5b3e04..b492cac
    
    Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
    Signed-off-by: U. Artie Eoff <ullysses.a.eoff@intel.com>