### PR TITLE
avcodec/dxva2_av1.c: fix global motion params

### DIFF
--- a/patches/0093-avcodec-dxva2_av1-fix-global-motion-params.patch
+++ b/patches/0093-avcodec-dxva2_av1-fix-global-motion-params.patch
@@ -1,0 +1,31 @@
+From 4e91679b3defec72b382cd4779bd275f9b68328b Mon Sep 17 00:00:00 2001
+From: Tong Wu <tong1.wu@intel.com>
+Date: Tue, 24 Aug 2021 09:30:33 +0800
+Subject: [PATCH] avcodec/dxva2_av1: fix global motion params
+
+Defined in spec 5.9.24/5.9.25. Since function void
+global_motion_params(AV1DecContext *s) already updates
+gm type/params, the wminvalid parameter only need to get
+the value from cur_frame.gm_invalid.
+
+Signed-off-by: Tong Wu <tong1.wu@intel.com>
+---
+ libavcodec/dxva2_av1.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/dxva2_av1.c b/libavcodec/dxva2_av1.c
+index aa14e473df..08fee6f7d5 100644
+--- a/libavcodec/dxva2_av1.c
++++ b/libavcodec/dxva2_av1.c
+@@ -139,7 +139,7 @@ static int fill_picture_parameters(const AVCodecContext *avctx, AVDXVAContext *c
+         pp->frame_refs[i].Index  = ref_frame->buf[0] ? ref_idx : 0xFF;
+ 
+         /* Global Motion */
+-        pp->frame_refs[i].wminvalid = (h->cur_frame.gm_type[AV1_REF_FRAME_LAST + i] == AV1_WARP_MODEL_IDENTITY);
++        pp->frame_refs[i].wminvalid = h->cur_frame.gm_invalid[AV1_REF_FRAME_LAST + i];
+         pp->frame_refs[i].wmtype    = h->cur_frame.gm_type[AV1_REF_FRAME_LAST + i];
+         for (j = 0; j < 6; ++j) {
+              pp->frame_refs[i].wmmat[j] = h->cur_frame.gm_params[AV1_REF_FRAME_LAST + i][j];
+-- 
+2.16.1.windows.4
+


### PR DESCRIPTION
Defined in spec 5.9.24/5.9.25. Since function void
global_motion_params(AV1DecContext *s) already updates
gm type/params, the wminvalid parameter only need to get
the value from cur_frame.gm_invalid.
