### PR TITLE
Fix bug when map qsv frame to vaapi frame

### DIFF
--- a/patches/0026-ffmpeg-Add-DX11-support-for-QSV.patch
+++ b/patches/0026-ffmpeg-Add-DX11-support-for-QSV.patch
@@ -792,7 +792,7 @@ index ebc15e09b3..3ec6a72606 100644
 -        child_data = (uint8_t*)(intptr_t)*(VASurfaceID*)surf->Data.MemId;
 +    {
 +        mfxHDLPair *pair = (mfxHDLPair*)surf->Data.MemId;
-+        child_data = pair->first;
++        child_data = (uint8_t*)(intptr_t)*(VASurfaceID*)pair->first;
          break;
 +    }
 +#endif


### PR DESCRIPTION
Need to apply this patch first [https://github.com/intel-media-ci/cartwheel-ffmpeg/pull/55/commits/5252d0201b3d152555822732b883635cfaba6c54#diff-c11fc2b8b76e638331ef39065bee6e261a45706194fe36a59a0f3e1af5fddf9f](https://github.com/intel-media-ci/cartwheel-ffmpeg/pull/55/commits/5252d0201b3d152555822732b883635cfaba6c54#diff-c11fc2b8b76e638331ef39065bee6e261a45706194fe36a59a0f3e1af5fddf9f)
```
ffmpeg -v verbose -hwaccel qsv -c:v h264_qsv -i input_1080p.264 -vf
"hwmap=derive_device=vaapi,format=vaapi,hwdownload,format=nv12" -f rawvideo output.yuv
```
Report error. 
For vaapi frame, data[3] store VASurfaceID while mfxHDLPair->first is *VASurfaceID.
I fix the type conversion code and the command works. 
