### PR TITLE
Fix vaapi overlay patch

### DIFF
--- a/patches/0001-lavu-pixfmt-add-new-pixel-format-0yuv-y410.patch
+++ b/patches/0001-lavu-pixfmt-add-new-pixel-format-0yuv-y410.patch
@@ -1,4 +1,4 @@
-From e563ff8e75978e9173d274a78ffd02a3f7992108 Mon Sep 17 00:00:00 2001
+From 0eecf7fffd552e9e8eab3915e557bb7081b593d3 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 15 Jun 2020 10:58:19 +0800
 Subject: [PATCH 01/92] lavu/pixfmt: add new pixel format 0yuv/y410
@@ -25,7 +25,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  4 files changed, 54 insertions(+)
 
 diff --git a/libavutil/pixdesc.c b/libavutil/pixdesc.c
-index 69cb198646..136a4f82a2 100644
+index 69cb19864677..136a4f82a271 100644
 --- a/libavutil/pixdesc.c
 +++ b/libavutil/pixdesc.c
 @@ -224,6 +224,41 @@ static const AVPixFmtDescriptor av_pix_fmt_descriptors[AV_PIX_FMT_NB] = {
@@ -71,7 +71,7 @@ index 69cb198646..136a4f82a2 100644
          .name = "rgb24",
          .nb_components = 3,
 diff --git a/libavutil/pixfmt.h b/libavutil/pixfmt.h
-index 53bdecfcb7..184ded7e85 100644
+index 53bdecfcb7a1..184ded7e8530 100644
 --- a/libavutil/pixfmt.h
 +++ b/libavutil/pixfmt.h
 @@ -348,6 +348,10 @@ enum AVPixelFormat {
@@ -94,7 +94,7 @@ index 53bdecfcb7..184ded7e85 100644
  #define AV_PIX_FMT_X2BGR10    AV_PIX_FMT_NE(X2BGR10BE, X2BGR10LE)
  
 diff --git a/tests/ref/fate/imgutils b/tests/ref/fate/imgutils
-index 495bbd46f0..290e87c2d9 100644
+index 495bbd46f00b..290e87c2d9e8 100644
 --- a/tests/ref/fate/imgutils
 +++ b/tests/ref/fate/imgutils
 @@ -234,6 +234,9 @@ nv24            planes: 2, linesizes:  64 128   0   0, plane_sizes:  3072  6144
@@ -108,7 +108,7 @@ index 495bbd46f0..290e87c2d9 100644
  x2rgb10be       planes: 1, linesizes: 256   0   0   0, plane_sizes: 12288     0     0     0, plane_offsets:     0     0     0, total_size: 12288
  x2bgr10le       planes: 1, linesizes: 256   0   0   0, plane_sizes: 12288     0     0     0, plane_offsets:     0     0     0, total_size: 12288
 diff --git a/tests/ref/fate/sws-pixdesc-query b/tests/ref/fate/sws-pixdesc-query
-index a74109c3d7..7613ba7524 100644
+index a74109c3d751..7613ba75246f 100644
 --- a/tests/ref/fate/sws-pixdesc-query
 +++ b/tests/ref/fate/sws-pixdesc-query
 @@ -65,6 +65,8 @@ isNBPS:
@@ -172,5 +172,5 @@ index a74109c3d7..7613ba7524 100644
    ya16le
    ya8
 -- 
-2.25.1
+2.25.4
 

--- a/patches/0002-swscale-Add-swscale-and-fate-support-for-0YUV.patch
+++ b/patches/0002-swscale-Add-swscale-and-fate-support-for-0YUV.patch
@@ -1,4 +1,4 @@
-From 07d981664fe6643883ebc0d11cb12d3391fac0da Mon Sep 17 00:00:00 2001
+From d03cb7c66abdf8832e5cf587dd3dfbd350438edc Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 15 Jun 2020 15:38:48 +0800
 Subject: [PATCH 02/92] swscale: Add swscale and fate support for 0YUV
@@ -32,7 +32,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  create mode 100644 tests/ref/fate/filter-pixdesc-0yuv
 
 diff --git a/libswscale/input.c b/libswscale/input.c
-index 477dc3d6b2..c7ea6187a5 100644
+index 477dc3d6b214..c7ea6187a5f5 100644
 --- a/libswscale/input.c
 +++ b/libswscale/input.c
 @@ -574,6 +574,25 @@ static void y210le_Y_c(uint8_t *dst, const uint8_t *src, const uint8_t *unused0,
@@ -82,7 +82,7 @@ index 477dc3d6b2..c7ea6187a5 100644
          c->lumToYV12 = rgb30leToY_c;
          break;
 diff --git a/libswscale/output.c b/libswscale/output.c
-index 58b10f85a5..c5cd974fa7 100644
+index 58b10f85a599..c5cd974fa7f4 100644
 --- a/libswscale/output.c
 +++ b/libswscale/output.c
 @@ -2502,6 +2502,53 @@ yuv2ya8_X_c(SwsContext *c, const int16_t *lumFilter,
@@ -150,7 +150,7 @@ index 58b10f85a5..c5cd974fa7 100644
          *yuv2packedX = yuv2ayuv64le_X_c;
          break;
 diff --git a/libswscale/swscale_unscaled.c b/libswscale/swscale_unscaled.c
-index 7cb2a62f07..16fa443833 100644
+index 7cb2a62f07f1..16fa443833d2 100644
 --- a/libswscale/swscale_unscaled.c
 +++ b/libswscale/swscale_unscaled.c
 @@ -371,6 +371,41 @@ static int yuv422pToUyvyWrapper(SwsContext *c, const uint8_t *src[],
@@ -208,7 +208,7 @@ index 7cb2a62f07..16fa443833 100644
      if (srcFormat == AV_PIX_FMT_GRAY8 && dstFormat == AV_PIX_FMT_GRAYF32){
          c->convert_unscaled = uint_y_to_float_y_wrapper;
 diff --git a/libswscale/utils.c b/libswscale/utils.c
-index 367b0ea501..76ecd1bd1d 100644
+index 367b0ea50153..76ecd1bd1d54 100644
 --- a/libswscale/utils.c
 +++ b/libswscale/utils.c
 @@ -266,6 +266,7 @@ static const FormatEntry format_entries[] = {
@@ -221,13 +221,13 @@ index 367b0ea501..76ecd1bd1d 100644
  };
 diff --git a/tests/ref/fate/filter-pixdesc-0yuv b/tests/ref/fate/filter-pixdesc-0yuv
 new file mode 100644
-index 0000000000..fb71b0b737
+index 000000000000..fb71b0b737ff
 --- /dev/null
 +++ b/tests/ref/fate/filter-pixdesc-0yuv
 @@ -0,0 +1 @@
 +pixdesc-0yuv        25e04681539b84434e6687583d196771
 diff --git a/tests/ref/fate/filter-pixfmts-copy b/tests/ref/fate/filter-pixfmts-copy
-index 790b733112..5cae303ca7 100644
+index 790b73311212..5cae303ca788 100644
 --- a/tests/ref/fate/filter-pixfmts-copy
 +++ b/tests/ref/fate/filter-pixfmts-copy
 @@ -1,5 +1,6 @@
@@ -238,7 +238,7 @@ index 790b733112..5cae303ca7 100644
  argb                f003b555ef429222005d33844cca9325
  ayuv64le            07b9c969dfbe4add4c0626773b151d4f
 diff --git a/tests/ref/fate/filter-pixfmts-crop b/tests/ref/fate/filter-pixfmts-crop
-index 3c410cbd6b..e7cbc6b13f 100644
+index 3c410cbd6baf..e7cbc6b13fd1 100644
 --- a/tests/ref/fate/filter-pixfmts-crop
 +++ b/tests/ref/fate/filter-pixfmts-crop
 @@ -1,5 +1,6 @@
@@ -249,7 +249,7 @@ index 3c410cbd6b..e7cbc6b13f 100644
  argb                8b822972049a1e207000763f2564d6e0
  ayuv64le            ab2f7bc8f150af47c42c778e3ea28bce
 diff --git a/tests/ref/fate/filter-pixfmts-field b/tests/ref/fate/filter-pixfmts-field
-index 37718d81d0..7897d0ff05 100644
+index 37718d81d0a1..7897d0ff056b 100644
 --- a/tests/ref/fate/filter-pixfmts-field
 +++ b/tests/ref/fate/filter-pixfmts-field
 @@ -1,5 +1,6 @@
@@ -260,7 +260,7 @@ index 37718d81d0..7897d0ff05 100644
  argb                6dca4f2987b49b7d63f702d17bace630
  ayuv64le            d9836decca6323ba88b3b3d02257c0b6
 diff --git a/tests/ref/fate/filter-pixfmts-fieldorder b/tests/ref/fate/filter-pixfmts-fieldorder
-index 88780c05a7..0221689d97 100644
+index 88780c05a714..0221689d9795 100644
 --- a/tests/ref/fate/filter-pixfmts-fieldorder
 +++ b/tests/ref/fate/filter-pixfmts-fieldorder
 @@ -1,5 +1,6 @@
@@ -271,7 +271,7 @@ index 88780c05a7..0221689d97 100644
  argb                80d08e68cb91bc8f2f817516e65f0bd0
  ayuv64le            84ef6260fe02427da946d4a2207fb54c
 diff --git a/tests/ref/fate/filter-pixfmts-hflip b/tests/ref/fate/filter-pixfmts-hflip
-index 69c7b42b6e..8de1b9864d 100644
+index 69c7b42b6eb3..8de1b9864dac 100644
 --- a/tests/ref/fate/filter-pixfmts-hflip
 +++ b/tests/ref/fate/filter-pixfmts-hflip
 @@ -1,5 +1,6 @@
@@ -282,7 +282,7 @@ index 69c7b42b6e..8de1b9864d 100644
  argb                36cf791c52c5463bfc52a070de54337e
  ayuv64le            4cedbc38b3d4dcb26cdab170ce6d667b
 diff --git a/tests/ref/fate/filter-pixfmts-il b/tests/ref/fate/filter-pixfmts-il
-index 09fe072314..82db3be1e7 100644
+index 09fe07231496..82db3be1e7ad 100644
 --- a/tests/ref/fate/filter-pixfmts-il
 +++ b/tests/ref/fate/filter-pixfmts-il
 @@ -1,5 +1,6 @@
@@ -293,7 +293,7 @@ index 09fe072314..82db3be1e7 100644
  argb                9e50e6ef02c83f28e97865a1f46ddfcd
  ayuv64le            6f45f683e99ddf4180c7c7f47719efcc
 diff --git a/tests/ref/fate/filter-pixfmts-null b/tests/ref/fate/filter-pixfmts-null
-index 790b733112..5cae303ca7 100644
+index 790b73311212..5cae303ca788 100644
 --- a/tests/ref/fate/filter-pixfmts-null
 +++ b/tests/ref/fate/filter-pixfmts-null
 @@ -1,5 +1,6 @@
@@ -304,7 +304,7 @@ index 790b733112..5cae303ca7 100644
  argb                f003b555ef429222005d33844cca9325
  ayuv64le            07b9c969dfbe4add4c0626773b151d4f
 diff --git a/tests/ref/fate/filter-pixfmts-pad b/tests/ref/fate/filter-pixfmts-pad
-index 57fa817cf5..65eb3d0b1b 100644
+index 57fa817cf5ed..65eb3d0b1b3d 100644
 --- a/tests/ref/fate/filter-pixfmts-pad
 +++ b/tests/ref/fate/filter-pixfmts-pad
 @@ -1,5 +1,6 @@
@@ -315,7 +315,7 @@ index 57fa817cf5..65eb3d0b1b 100644
  argb                2a10108ac524b422b8a2393c064b3eab
  bgr0                32207a2de1b2ac7937e940a8459b97c0
 diff --git a/tests/ref/fate/filter-pixfmts-scale b/tests/ref/fate/filter-pixfmts-scale
-index 07c4ff536d..15643029b7 100644
+index 07c4ff536d16..15643029b7b2 100644
 --- a/tests/ref/fate/filter-pixfmts-scale
 +++ b/tests/ref/fate/filter-pixfmts-scale
 @@ -1,5 +1,6 @@
@@ -326,7 +326,7 @@ index 07c4ff536d..15643029b7 100644
  argb                f0e17c71a40643c33a5bcfb481f6d8f8
  ayuv64le            59fb016f9874062d0be77cb3920ffed2
 diff --git a/tests/ref/fate/filter-pixfmts-transpose b/tests/ref/fate/filter-pixfmts-transpose
-index 5117bcf763..275e5c8b62 100644
+index 5117bcf763f2..275e5c8b62bd 100644
 --- a/tests/ref/fate/filter-pixfmts-transpose
 +++ b/tests/ref/fate/filter-pixfmts-transpose
 @@ -1,5 +1,6 @@
@@ -337,7 +337,7 @@ index 5117bcf763..275e5c8b62 100644
  argb                87bbd23debb94d486ac3a6b6c0b005f9
  ayuv64le            e4c07e0d5b333b3bc9eb4f3ce6af3a2c
 diff --git a/tests/ref/fate/filter-pixfmts-vflip b/tests/ref/fate/filter-pixfmts-vflip
-index 34c1a9c64f..f8b9ea8da7 100644
+index 34c1a9c64fc9..f8b9ea8da7d3 100644
 --- a/tests/ref/fate/filter-pixfmts-vflip
 +++ b/tests/ref/fate/filter-pixfmts-vflip
 @@ -1,5 +1,6 @@
@@ -348,5 +348,5 @@ index 34c1a9c64f..f8b9ea8da7 100644
  argb                3fd6af7ef2364d8aa845d45db289a04a
  ayuv64le            558671dd31d0754cfa6344eaf441df78
 -- 
-2.25.1
+2.25.4
 

--- a/patches/0003-lavu-hwcontext_vaapi-add-vaapi_format_map-support-fo.patch
+++ b/patches/0003-lavu-hwcontext_vaapi-add-vaapi_format_map-support-fo.patch
@@ -1,7 +1,7 @@
-From b7a1b9f23a53a04d5fb27d13daa1d09a7fd1ec60 Mon Sep 17 00:00:00 2001
+From ab402e69eae78da40a0029a068d6cb0b2fe06fb4 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 10 Sep 2019 16:47:27 +0800
-Subject: [PATCH 03/82] lavu/hwcontext_vaapi: add vaapi_format_map support for
+Subject: [PATCH 03/92] lavu/hwcontext_vaapi: add vaapi_format_map support for
  0YUV/Y410
 
 VA_RT_FORMAT describes the desired sampling format for surface.

--- a/patches/0004-qsv-get-FrameInfo.Shift-by-desc-comp-0-.shift.patch
+++ b/patches/0004-qsv-get-FrameInfo.Shift-by-desc-comp-0-.shift.patch
@@ -1,7 +1,7 @@
-From 6c31aad76c6973a6d3fc29838b522eaf84ab9090 Mon Sep 17 00:00:00 2001
+From bbf9e47056e52b516655ba2da8759aabc154c6bf Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 18 May 2020 16:32:40 +0800
-Subject: [PATCH 04/82] qsv: get FrameInfo.Shift by desc->comp[0].shift
+Subject: [PATCH 04/92] qsv: get FrameInfo.Shift by desc->comp[0].shift
 
 Signed-off-by: Linjie Fu <linjie.fu@intel.com>
 ---
@@ -10,10 +10,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 0ec8e0e59728..7511c18dd58e 100644
+index 06f55604b576..2edc4adfb456 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -448,7 +448,7 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
+@@ -452,7 +452,7 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
      q->param.mfx.FrameInfo.ChromaFormat   = MFX_CHROMAFORMAT_YUV420;
      q->param.mfx.FrameInfo.BitDepthLuma   = desc->comp[0].depth;
      q->param.mfx.FrameInfo.BitDepthChroma = desc->comp[0].depth;
@@ -22,7 +22,7 @@ index 0ec8e0e59728..7511c18dd58e 100644
  
      q->param.mfx.FrameInfo.Width  = FFALIGN(avctx->width, 16);
      q->param.mfx.FrameInfo.Height = FFALIGN(avctx->height, 16);
-@@ -550,7 +550,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -556,7 +556,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
                                              !desc->log2_chroma_w + !desc->log2_chroma_h;
      q->param.mfx.FrameInfo.BitDepthLuma   = desc->comp[0].depth;
      q->param.mfx.FrameInfo.BitDepthChroma = desc->comp[0].depth;
@@ -32,10 +32,10 @@ index 0ec8e0e59728..7511c18dd58e 100644
      // If the minor version is greater than or equal to 19,
      // then can use the same alignment settings as H.264 for HEVC
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 08a6e0ee1c68..a21907ef5e8f 100644
+index c18747f7eb9b..0700cba80221 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -327,7 +327,7 @@ static int qsv_init_surface(AVHWFramesContext *ctx, mfxFrameSurface1 *surf)
+@@ -404,7 +404,7 @@ static int qsv_init_surface(AVHWFramesContext *ctx, mfxFrameSurface1 *surf)
  
      surf->Info.BitDepthLuma   = desc->comp[0].depth;
      surf->Info.BitDepthChroma = desc->comp[0].depth;

--- a/patches/0005-lavcu-qsv-Add-decoding-support-for-444-8-10-bit.patch
+++ b/patches/0005-lavcu-qsv-Add-decoding-support-for-444-8-10-bit.patch
@@ -1,7 +1,7 @@
-From 3b0d204625c3a98b0c38ae95188fac6ea8733438 Mon Sep 17 00:00:00 2001
+From 650788b0b7aae606ade2ee2fd1f88da80cc69521 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 18 May 2020 16:54:57 +0800
-Subject: [PATCH 05/82] lavcu/qsv: Add decoding support for 444 8/10 bit
+Subject: [PATCH 05/92] lavcu/qsv: Add decoding support for 444 8/10 bit
 
 Signed-off-by: Linjie Fu <linjie.fu@intel.com>
 ---
@@ -10,10 +10,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 29 insertions(+)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 6e3154e1a39f..f2d3b74a96df 100644
+index 9d08485c9203..47dec181a153 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
-@@ -201,8 +201,12 @@ enum AVPixelFormat ff_qsv_map_fourcc(uint32_t fourcc)
+@@ -191,8 +191,12 @@ enum AVPixelFormat ff_qsv_map_fourcc(uint32_t fourcc)
      case MFX_FOURCC_P8:   return AV_PIX_FMT_PAL8;
  #if CONFIG_VAAPI
      case MFX_FOURCC_YUY2: return AV_PIX_FMT_YUYV422;
@@ -26,7 +26,7 @@ index 6e3154e1a39f..f2d3b74a96df 100644
  #endif
  #endif
      }
-@@ -226,11 +230,21 @@ int ff_qsv_map_pixfmt(enum AVPixelFormat format, uint32_t *fourcc)
+@@ -216,11 +220,21 @@ int ff_qsv_map_pixfmt(enum AVPixelFormat format, uint32_t *fourcc)
      case AV_PIX_FMT_YUYV422:
          *fourcc = MFX_FOURCC_YUY2;
          return AV_PIX_FMT_YUYV422;
@@ -49,10 +49,10 @@ index 6e3154e1a39f..f2d3b74a96df 100644
  #endif
      default:
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index a21907ef5e8f..ebc15e09b37f 100644
+index 0700cba80221..362108e26aab 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -110,9 +110,15 @@ static const struct {
+@@ -103,9 +103,15 @@ static const struct {
  #if CONFIG_VAAPI
      { AV_PIX_FMT_YUYV422,
                         MFX_FOURCC_YUY2 },
@@ -68,7 +68,7 @@ index a21907ef5e8f..ebc15e09b37f 100644
  #endif
  #endif
  };
-@@ -797,6 +803,15 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
+@@ -931,6 +937,15 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
          surface->Data.U16 = (mfxU16 *)frame->data[0] + 1;
          surface->Data.V16 = (mfxU16 *)frame->data[0] + 3;
          break;

--- a/patches/0006-lavc-vaapi_decode-Add-4-4-4-8-10-bit-decode-support-.patch
+++ b/patches/0006-lavc-vaapi_decode-Add-4-4-4-8-10-bit-decode-support-.patch
@@ -1,7 +1,7 @@
-From 847d3b9b3df385e6518a280cea4d9ffa9b3dada5 Mon Sep 17 00:00:00 2001
+From e03299e816555655c4c4495ff16bac1afa3cbb72 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 20 Sep 2019 10:07:02 +0800
-Subject: [PATCH 06/82] lavc/vaapi_decode: Add 4:4:4 8/10 bit decode support
+Subject: [PATCH 06/92] lavc/vaapi_decode: Add 4:4:4 8/10 bit decode support
  for VP9
 
 VP9 4:4:4 8 bit and 10 bit decode are supported since Ice Lake.
@@ -27,10 +27,10 @@ index 958ddf49da84..f454254ec0c1 100644
  #if VA_CHECK_VERSION(1, 8, 0)
      MAP(AV1,         AV1_MAIN,        AV1Profile0),
 diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
-index 32776ebae764..c336686233b9 100644
+index 8317ac6bd84c..619dd1bfea59 100644
 --- a/libavcodec/vp9.c
 +++ b/libavcodec/vp9.c
-@@ -234,6 +234,12 @@ static int update_size(AVCodecContext *avctx, int w, int h)
+@@ -223,6 +223,12 @@ static int update_size(AVCodecContext *avctx, int w, int h)
  #endif
  #if CONFIG_VP9_VDPAU_HWACCEL
              *fmtp++ = AV_PIX_FMT_VDPAU;

--- a/patches/0007-lavc-vaapi_encode_h265-add-support-for-low-power-mod.patch
+++ b/patches/0007-lavc-vaapi_encode_h265-add-support-for-low-power-mod.patch
@@ -1,7 +1,7 @@
-From 927d34a87f3241775f485ca2d53187829bc3f322 Mon Sep 17 00:00:00 2001
+From 189a1e2f12d4b305b3317021897e2253ed135fe9 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 3 Dec 2019 16:07:48 +0800
-Subject: [PATCH 07/82] lavc/vaapi_encode_h265: add support for low power mode
+Subject: [PATCH 07/92] lavc/vaapi_encode_h265: add support for low power mode
  for HEVC encode
 
 Enable hevc_vaapi vdenc:

--- a/patches/0008-avcodec-vaapi-set-more-flags-for-VASurfaceAttrib.patch
+++ b/patches/0008-avcodec-vaapi-set-more-flags-for-VASurfaceAttrib.patch
@@ -1,7 +1,7 @@
-From 2fdcf81b6121c859bc88f16258a4072aa067061b Mon Sep 17 00:00:00 2001
+From 1a9bc04afc4716ba5b3207eefc8a6d8d7ae817b8 Mon Sep 17 00:00:00 2001
 From: Wangfei <fei.w.wang@intel.com>
 Date: Tue, 19 Nov 2019 16:23:19 +0800
-Subject: [PATCH 08/82] avcodec/vaapi: set more flags for VASurfaceAttrib
+Subject: [PATCH 08/92] avcodec/vaapi: set more flags for VASurfaceAttrib
 
 flags and value.type is needed when pass VASurfaceAttrib to driver.
 Otherwise the attribute will be considered invalid in driver.

--- a/patches/0009-lavc-vaapi_encode-add-support-for-maxframesize.patch
+++ b/patches/0009-lavc-vaapi_encode-add-support-for-maxframesize.patch
@@ -1,7 +1,7 @@
-From 8b77c00366e9d663be2d22f696b17351b583cc16 Mon Sep 17 00:00:00 2001
+From 70e4427fef205182423ced9ffcae6cef5319d891 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 22 Jun 2020 09:51:24 +0800
-Subject: [PATCH 09/82] lavc/vaapi_encode: add support for maxframesize
+Subject: [PATCH 09/92] lavc/vaapi_encode: add support for maxframesize
 
 Add support for max frame size:
     - max_frame_size (bytes) to indicate the max allowed size for frame.
@@ -31,7 +31,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 84 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 7510816ec193..63de9a0a3b6b 100644
+index ec054ae70152..bdd6430e2a5a 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -348,7 +348,16 @@ static int vaapi_encode_issue(AVCodecContext *avctx,

--- a/patches/0010-doc-vaapi_encode-add-documentations-for-max_frame_si.patch
+++ b/patches/0010-doc-vaapi_encode-add-documentations-for-max_frame_si.patch
@@ -1,7 +1,7 @@
-From dc3e2dd211f543a78cb87e4aaac9c88047bfbbee Mon Sep 17 00:00:00 2001
+From 73067607e01a8d6adde20c9322eb695ca0a2cdf9 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 21 Jun 2019 00:39:08 +0800
-Subject: [PATCH 10/82] doc/vaapi_encode: add documentations for max_frame_size
+Subject: [PATCH 10/92] doc/vaapi_encode: add documentations for max_frame_size
 
 Add docs for max_frame_size option.
 
@@ -11,10 +11,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 6 insertions(+)
 
 diff --git a/doc/encoders.texi b/doc/encoders.texi
-index 2ba9938da2a2..3f549d32030c 100644
+index 8a7589c2458c..2c90a282a85c 100644
 --- a/doc/encoders.texi
 +++ b/doc/encoders.texi
-@@ -3268,6 +3268,12 @@ will refer only to P- or I-frames.  When set to greater values multiple layers
+@@ -3286,6 +3286,12 @@ will refer only to P- or I-frames.  When set to greater values multiple layers
  of B-frames will be present, frames in each layer only referring to frames in
  higher layers.
  

--- a/patches/0011-fftools-ffmpeg-support-variable-resolution-encode.patch
+++ b/patches/0011-fftools-ffmpeg-support-variable-resolution-encode.patch
@@ -1,7 +1,7 @@
-From 0e00f8a92773b14a680dad8a2ab76ee2e590b3d0 Mon Sep 17 00:00:00 2001
+From 11df2d100830f2b7d726fbe3730f586f9c33c78b Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Mon, 2 Nov 2020 10:45:29 +0800
-Subject: [PATCH] fftools/ffmpeg: support variable resolution encode
+Subject: [PATCH 11/92] fftools/ffmpeg: support variable resolution encode
 
 Flush encoders when resolution change happens.
 
@@ -15,7 +15,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 15 insertions(+), 1 deletion(-)
 
 diff --git a/fftools/ffmpeg.c b/fftools/ffmpeg.c
-index 3ad11452da53..155d1106c14d 100644
+index bb29e3cec5e9..e9920fc26faf 100644
 --- a/fftools/ffmpeg.c
 +++ b/fftools/ffmpeg.c
 @@ -130,6 +130,7 @@ static void do_video_stats(OutputStream *ost, int frame_size);
@@ -26,7 +26,7 @@ index 3ad11452da53..155d1106c14d 100644
  
  static int run_as_daemon  = 0;
  static int nb_frames_dup = 0;
-@@ -1161,6 +1162,19 @@ static void do_video_out(OutputFile *of,
+@@ -1162,6 +1163,19 @@ static void do_video_out(OutputFile *of,
      init_output_stream_wrapper(ost, next_picture, 1);
      sync_ipts = adjust_frame_pts_to_encoder_tb(of, ost, next_picture);
  
@@ -47,10 +47,10 @@ index 3ad11452da53..155d1106c14d 100644
          ist = input_streams[ost->source_index];
  
 diff --git a/libavcodec/rawenc.c b/libavcodec/rawenc.c
-index bd992239a593..3166b46fdd28 100644
+index 7e15084d71cb..7827086af015 100644
 --- a/libavcodec/rawenc.c
 +++ b/libavcodec/rawenc.c
-@@ -86,7 +86,7 @@ const AVCodec ff_rawvideo_encoder = {
+@@ -85,7 +85,7 @@ const AVCodec ff_rawvideo_encoder = {
      .long_name      = NULL_IF_CONFIG_SMALL("raw video"),
      .type           = AVMEDIA_TYPE_VIDEO,
      .id             = AV_CODEC_ID_RAWVIDEO,

--- a/patches/0012-lavc-libvpxenc-add-dynamic-resolution-encode-support.patch
+++ b/patches/0012-lavc-libvpxenc-add-dynamic-resolution-encode-support.patch
@@ -1,7 +1,7 @@
-From 3385f5cc04d1004cb62b096c79a8623fcad81669 Mon Sep 17 00:00:00 2001
+From a1e7ca66d6ae1392cdcadb897f12baf892c8049f Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Wed, 31 Jul 2019 12:18:21 +0800
-Subject: [PATCH 12/82] lavc/libvpxenc: add dynamic resolution encode support
+Subject: [PATCH 12/92] lavc/libvpxenc: add dynamic resolution encode support
  for libvpx
 
 According to spec, libvpx should support dynamic resolution changes.
@@ -21,10 +21,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 32 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/libvpxenc.c b/libavcodec/libvpxenc.c
-index 66bad444d0ed..83eab20fa93d 100644
+index 10e5a22fa92c..0a4083fc7b91 100644
 --- a/libavcodec/libvpxenc.c
 +++ b/libavcodec/libvpxenc.c
-@@ -1543,6 +1543,34 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
+@@ -1640,6 +1640,34 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
      vpx_svc_layer_id_t layer_id;
      int layer_id_valid = 0;
  
@@ -59,7 +59,7 @@ index 66bad444d0ed..83eab20fa93d 100644
      if (frame) {
          const AVFrameSideData *sd = av_frame_get_side_data(frame, AV_FRAME_DATA_REGIONS_OF_INTEREST);
          rawimg                      = &ctx->rawimg;
-@@ -1552,6 +1580,8 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
+@@ -1649,6 +1677,8 @@ static int vpx_encode(AVCodecContext *avctx, AVPacket *pkt,
          rawimg->stride[VPX_PLANE_Y] = frame->linesize[0];
          rawimg->stride[VPX_PLANE_U] = frame->linesize[1];
          rawimg->stride[VPX_PLANE_V] = frame->linesize[2];
@@ -68,7 +68,7 @@ index 66bad444d0ed..83eab20fa93d 100644
          if (ctx->is_alpha) {
              rawimg_alpha = &ctx->rawimg_alpha;
              res = realloc_alpha_uv(avctx, frame->width, frame->height);
-@@ -1830,7 +1860,7 @@ const AVCodec ff_libvpx_vp8_encoder = {
+@@ -1946,7 +1976,7 @@ const AVCodec ff_libvpx_vp8_encoder = {
      .type           = AVMEDIA_TYPE_VIDEO,
      .id             = AV_CODEC_ID_VP8,
      .capabilities   = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_DELAY |
@@ -77,7 +77,7 @@ index 66bad444d0ed..83eab20fa93d 100644
      .priv_data_size = sizeof(VPxContext),
      .init           = vp8_init,
      .encode2        = vpx_encode,
-@@ -1862,7 +1892,7 @@ AVCodec ff_libvpx_vp9_encoder = {
+@@ -1978,7 +2008,7 @@ AVCodec ff_libvpx_vp9_encoder = {
      .type           = AVMEDIA_TYPE_VIDEO,
      .id             = AV_CODEC_ID_VP9,
      .capabilities   = AV_CODEC_CAP_DR1 | AV_CODEC_CAP_DELAY |

--- a/patches/0013-lavf-vf_deinterlace_vaapi-flush-queued-frame-for-fie.patch
+++ b/patches/0013-lavf-vf_deinterlace_vaapi-flush-queued-frame-for-fie.patch
@@ -1,7 +1,7 @@
-From dd223f6de119a833598591231a32908de61affa7 Mon Sep 17 00:00:00 2001
+From a1397b5552d58e7522e880522981283ebfaec65e Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 2 Aug 2019 16:11:38 +0800
-Subject: [PATCH 13/94] lavf/vf_deinterlace_vaapi: flush queued frame for field
+Subject: [PATCH 13/92] lavf/vf_deinterlace_vaapi: flush queued frame for field
  in DeinterlacingBob
 
 For DeinterlacingBob mode with rate=field, the frame number of output
@@ -31,7 +31,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 38 insertions(+), 6 deletions(-)
 
 diff --git a/libavfilter/vf_deinterlace_vaapi.c b/libavfilter/vf_deinterlace_vaapi.c
-index 5ec830213e..ab5c377231 100644
+index 65f319ba9aaa..68b14a9fba4c 100644
 --- a/libavfilter/vf_deinterlace_vaapi.c
 +++ b/libavfilter/vf_deinterlace_vaapi.c
 @@ -46,6 +46,9 @@ typedef struct DeintVAAPIContext {
@@ -128,5 +128,5 @@ index 5ec830213e..ab5c377231 100644
  };
  
 -- 
-2.25.1
+2.25.4
 

--- a/patches/0014-lavc-decode-Add-get_hw_config-function.patch
+++ b/patches/0014-lavc-decode-Add-get_hw_config-function.patch
@@ -1,7 +1,7 @@
-From 4f75c4993a969dfa82b79628e0f0bb7206bc565c Mon Sep 17 00:00:00 2001
+From 308a67f70b4a55b5972f7ee6d480445f501972ef Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 2 Jan 2020 11:06:45 +0800
-Subject: [PATCH 14/82] lavc/decode: Add get_hw_config function
+Subject: [PATCH 14/92] lavc/decode: Add get_hw_config function
 
 Wrap the procedure of getting the hardware config from a pixel format
 into a function.
@@ -12,10 +12,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 21 insertions(+), 12 deletions(-)
 
 diff --git a/libavcodec/decode.c b/libavcodec/decode.c
-index cd98c98a9739..5c11780b76c4 100644
+index 294c04071636..b69cb0dfaae7 100644
 --- a/libavcodec/decode.c
 +++ b/libavcodec/decode.c
-@@ -1069,6 +1069,26 @@ static void hwaccel_uninit(AVCodecContext *avctx)
+@@ -1084,6 +1084,26 @@ static void hwaccel_uninit(AVCodecContext *avctx)
      av_buffer_unref(&avctx->hw_frames_ctx);
  }
  
@@ -42,7 +42,7 @@ index cd98c98a9739..5c11780b76c4 100644
  int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
  {
      const AVPixFmtDescriptor *desc;
-@@ -1128,18 +1148,7 @@ int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
+@@ -1143,18 +1163,7 @@ int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
              break;
          }
  

--- a/patches/0015-lavc-decode-Add-internal-surface-re-allocate-method-.patch
+++ b/patches/0015-lavc-decode-Add-internal-surface-re-allocate-method-.patch
@@ -1,7 +1,7 @@
-From ec9395bf4f1adf730c88971a3be93945bbf1398e Mon Sep 17 00:00:00 2001
+From ec2d03ff53f248d5f82d0f1ce4315a586d1f39f1 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 2 Jan 2020 11:12:15 +0800
-Subject: [PATCH 15/82] lavc/decode: Add internal surface re-allocate method
+Subject: [PATCH 15/92] lavc/decode: Add internal surface re-allocate method
  for hwaccel
 
 Add HWACCEL_CAP_INTERNAL_ALLOC flag to indicate hwaccels are able to
@@ -14,10 +14,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 37 insertions(+)
 
 diff --git a/libavcodec/decode.c b/libavcodec/decode.c
-index 5c11780b76c4..dd1719be9da2 100644
+index b69cb0dfaae7..93f9507f4dcb 100644
 --- a/libavcodec/decode.c
 +++ b/libavcodec/decode.c
-@@ -1089,6 +1089,33 @@ static const AVCodecHWConfigInternal *get_hw_config(AVCodecContext *avctx, enum
+@@ -1104,6 +1104,33 @@ static const AVCodecHWConfigInternal *get_hw_config(AVCodecContext *avctx, enum
      return hw_config;
  }
  
@@ -51,7 +51,7 @@ index 5c11780b76c4..dd1719be9da2 100644
  int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
  {
      const AVPixFmtDescriptor *desc;
-@@ -1117,6 +1144,15 @@ int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
+@@ -1132,6 +1159,15 @@ int ff_get_format(AVCodecContext *avctx, const enum AVPixelFormat *fmt)
      memcpy(choices, fmt, (n + 1) * sizeof(*choices));
  
      for (;;) {

--- a/patches/0016-lavc-vaapi_vp9-add-surface-internal-re-allocation-ca.patch
+++ b/patches/0016-lavc-vaapi_vp9-add-surface-internal-re-allocation-ca.patch
@@ -1,7 +1,7 @@
-From 3d018baa141be4491510681942f062fa9bb51b75 Mon Sep 17 00:00:00 2001
+From dac788d7ef5064dc1ba11aa4cf542719c8cf5391 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 2 Jan 2020 11:16:31 +0800
-Subject: [PATCH 16/82] lavc/vaapi_vp9: add surface internal re-allocation
+Subject: [PATCH 16/92] lavc/vaapi_vp9: add surface internal re-allocation
  capability
 
 Signed-off-by: Linjie Fu <linjie.fu@intel.com>

--- a/patches/0017-lavc-qsvenc-add-return-check-for-ff_qsv_map_pixfmt.patch
+++ b/patches/0017-lavc-qsvenc-add-return-check-for-ff_qsv_map_pixfmt.patch
@@ -1,7 +1,7 @@
-From 706605bdf6cb5183a4a829ee557e6ac26c6b9f26 Mon Sep 17 00:00:00 2001
+From 9a2b3778a45c88a219fddfd0e4660e2a5aab41a3 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 24 Feb 2020 19:27:19 +0800
-Subject: [PATCH 17/82] lavc/qsvenc: add return check for ff_qsv_map_pixfmt
+Subject: [PATCH 17/92] lavc/qsvenc: add return check for ff_qsv_map_pixfmt
 
 Return an error directly if pixfmt is not supported for encoding, otherwise
 it may be hidden until query/check in MSDK.
@@ -12,10 +12,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  1 file changed, 6 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 7511c18dd58e..f84c8a7e4b17 100644
+index 2edc4adfb456..032393b86bef 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -437,7 +437,9 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
+@@ -441,7 +441,9 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
      if (!desc)
          return AVERROR_BUG;
  
@@ -26,7 +26,7 @@ index 7511c18dd58e..f84c8a7e4b17 100644
  
      q->param.mfx.FrameInfo.CropX          = 0;
      q->param.mfx.FrameInfo.CropY          = 0;
-@@ -538,7 +540,9 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -544,7 +546,9 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
      if (!desc)
          return AVERROR_BUG;
  

--- a/patches/0018-lavc-vaapi_hevc-fill-rext-luma-chroma-offset-in-the-.patch
+++ b/patches/0018-lavc-vaapi_hevc-fill-rext-luma-chroma-offset-in-the-.patch
@@ -1,7 +1,7 @@
-From 291a71cf79867b97917676c64965e26b13659002 Mon Sep 17 00:00:00 2001
+From f9d9d55651065013e7725bcff939cf1ab7c3bdee Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Thu, 12 Mar 2020 12:04:53 -0400
-Subject: [PATCH 18/82] lavc/vaapi_hevc: fill rext luma/chroma offset in the
+Subject: [PATCH 18/92] lavc/vaapi_hevc: fill rext luma/chroma offset in the
  right way
 
 For range extension, the luma/chroma offset is larger than 8 bits, we need fill the 16 bits version

--- a/patches/0019-lavc-hevc-fix-dpb-logical-for-IRAP.patch
+++ b/patches/0019-lavc-hevc-fix-dpb-logical-for-IRAP.patch
@@ -1,7 +1,7 @@
-From 8e45dbaea0b02a9ed8659551016d723010d234cf Mon Sep 17 00:00:00 2001
+From 5ae4694ec40a878b090e23f40843f89f9c7d3f0d Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Fri, 13 Mar 2020 09:14:48 -0400
-Subject: [PATCH 19/82] lavc: hevc, fix dpb logical for IRAP
+Subject: [PATCH 19/92] lavc: hevc, fix dpb logical for IRAP
 
 According to C.5.2.2, item 2. When we got an IRAP, and the NoOutputOfPriorPicsFlag = 0,
 we need bump all outputable frames.

--- a/patches/0020-lavc-hevc-do-not-let-missing-ref-frames-invovle-in-d.patch
+++ b/patches/0020-lavc-hevc-do-not-let-missing-ref-frames-invovle-in-d.patch
@@ -1,7 +1,7 @@
-From 97dd4754907a701d80d7fe286e88d8d190b354f4 Mon Sep 17 00:00:00 2001
+From 3bd39a87b29e6a7a98d8d32e8fed297941867e15 Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Mon, 16 Mar 2020 03:51:40 -0400
-Subject: [PATCH 20/82] lavc: hevc, do not let missing ref frames invovle in
+Subject: [PATCH 20/92] lavc: hevc, do not let missing ref frames invovle in
  dpb process
 
 We will generate a new frame for a missed reference. The frame can only be used for reference.
@@ -46,10 +46,10 @@ index 9e391b0970d4..63e34f3fb7ed 100644
  
      if (s->threads_type == FF_THREAD_FRAME)
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index 2d35b0b1824a..cd686a825132 100644
+index 57a61752a3b6..9c355fbbaa71 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -550,7 +550,7 @@ static int hls_slice_header(HEVCContext *s)
+@@ -551,7 +551,7 @@ static int hls_slice_header(HEVCContext *s)
      }
  
      if ((IS_IDR(s) || IS_BLA(s)) && sh->first_slice_in_pic_flag) {
@@ -58,7 +58,7 @@ index 2d35b0b1824a..cd686a825132 100644
          s->max_ra     = INT_MAX;
          if (IS_IDR(s))
              ff_hevc_clear_refs(s);
-@@ -595,7 +595,7 @@ static int hls_slice_header(HEVCContext *s)
+@@ -596,7 +596,7 @@ static int hls_slice_header(HEVCContext *s)
              return pix_fmt;
          s->avctx->pix_fmt = pix_fmt;
  

--- a/patches/0021-lavc-hevc_refs-exclude-current-frame-from-long-term-.patch
+++ b/patches/0021-lavc-hevc_refs-exclude-current-frame-from-long-term-.patch
@@ -1,7 +1,7 @@
-From 54d2dd7650907833ff2a1de5522605202cd0f246 Mon Sep 17 00:00:00 2001
+From b7681825d84bdd68a87ad79db59471697cc506ea Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Tue, 9 Jun 2020 11:09:32 +0800
-Subject: [PATCH 21/82] lavc/hevc_refs: exclude current frame from long term
+Subject: [PATCH 21/92] lavc/hevc_refs: exclude current frame from long term
  refs
 
 suppose

--- a/patches/0022-lavc-hevc-respect-no_output_of_prior_pics_flag-even-.patch
+++ b/patches/0022-lavc-hevc-respect-no_output_of_prior_pics_flag-even-.patch
@@ -1,7 +1,7 @@
-From e9407c3e58793d138d39eb3e1e492fcac1e7f230 Mon Sep 17 00:00:00 2001
+From 79750629789f12691ddefd72da50829657ac629b Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Tue, 17 Mar 2020 06:03:15 -0400
-Subject: [PATCH 22/82] lavc: hevc, respect no_output_of_prior_pics_flag even
+Subject: [PATCH 22/92] lavc: hevc, respect no_output_of_prior_pics_flag even
  we have reslution change
 
 if we have resolution change, we still need follow no_output_of_prior_pics_flag
@@ -11,10 +11,10 @@ in next IDR.
  1 file changed, 7 deletions(-)
 
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index cd686a825132..df006a2d02a4 100644
+index 9c355fbbaa71..b95e930a5e0f 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -575,15 +575,8 @@ static int hls_slice_header(HEVCContext *s)
+@@ -576,15 +576,8 @@ static int hls_slice_header(HEVCContext *s)
  
      if (s->ps.sps != (HEVCSPS*)s->ps.sps_list[s->ps.pps->sps_id]->data) {
          const HEVCSPS *sps = (HEVCSPS*)s->ps.sps_list[s->ps.pps->sps_id]->data;

--- a/patches/0023-lavc-hevcdec-add-vaapi-decoding-support-for-444.patch
+++ b/patches/0023-lavc-hevcdec-add-vaapi-decoding-support-for-444.patch
@@ -1,7 +1,7 @@
-From d78c5c06545ed869b20713fc2de8404789136874 Mon Sep 17 00:00:00 2001
+From b62a5520e18c7522560c6f9448edf06edbbae407 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 14 Jul 2020 10:12:26 +0800
-Subject: [PATCH 23/82] lavc/hevcdec: add vaapi decoding support for 444
+Subject: [PATCH 23/92] lavc/hevcdec: add vaapi decoding support for 444
 
 Also include 420P12, 444P12.
 
@@ -12,10 +12,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 12 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index df006a2d02a4..688be94e4394 100644
+index b95e930a5e0f..bbd1a687f755 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
-@@ -442,6 +442,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -443,6 +443,9 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
  #endif
          break;
      case AV_PIX_FMT_YUV444P:
@@ -25,7 +25,7 @@ index df006a2d02a4..688be94e4394 100644
  #if CONFIG_HEVC_VDPAU_HWACCEL
          *fmt++ = AV_PIX_FMT_VDPAU;
  #endif
-@@ -452,12 +455,15 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
+@@ -453,12 +456,15 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
      case AV_PIX_FMT_YUV422P:
      case AV_PIX_FMT_YUV422P10LE:
  #if CONFIG_HEVC_VAAPI_HWACCEL

--- a/patches/0024-lavc-vaapi_encode_h265-add-private-b_strategy-option.patch
+++ b/patches/0024-lavc-vaapi_encode_h265-add-private-b_strategy-option.patch
@@ -1,7 +1,7 @@
-From 0c8d9aeb93e280eda4ab61914f1d09246ff30620 Mon Sep 17 00:00:00 2001
+From 2460a590a542e0f666b917675c5edcc9eb804e56 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 7 Apr 2020 14:03:21 +0800
-Subject: [PATCH 24/82] lavc/vaapi_encode_h265: add private b_strategy option
+Subject: [PATCH 24/92] lavc/vaapi_encode_h265: add private b_strategy option
  for hevc_vaapi
 
 Allow user to choose between I/P/B frames:
@@ -36,10 +36,10 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  4 files changed, 61 insertions(+), 6 deletions(-)
 
 diff --git a/doc/encoders.texi b/doc/encoders.texi
-index 3f549d32030c..48dc98658a69 100644
+index 2c90a282a85c..1eae6b125803 100644
 --- a/doc/encoders.texi
 +++ b/doc/encoders.texi
-@@ -3359,6 +3359,22 @@ Some combination of the following values:
+@@ -3377,6 +3377,22 @@ Some combination of the following values:
  Include HDR metadata if the input frames have it
  (@emph{mastering_display_colour_volume} and @emph{content_light_level}
  messages).
@@ -63,7 +63,7 @@ index 3f549d32030c..48dc98658a69 100644
  
  @item tiles
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 63de9a0a3b6b..4c8aa11e9e11 100644
+index bdd6430e2a5a..10d218d370a8 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -1911,15 +1911,26 @@ static av_cold int vaapi_encode_init_gop_structure(AVCodecContext *avctx)

--- a/patches/0025-lavc-vaapi_encode_h265-fix-max_transform_hierarchy_d.patch
+++ b/patches/0025-lavc-vaapi_encode_h265-fix-max_transform_hierarchy_d.patch
@@ -1,7 +1,7 @@
-From 7c7f75f61c1b0cd092ba98a26edba7f3396da77a Mon Sep 17 00:00:00 2001
+From c584b639cd4d46065fd78b362437524e3b04bc68 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 27 Mar 2020 14:01:44 +0800
-Subject: [PATCH 25/82] lavc/vaapi_encode_h265: fix
+Subject: [PATCH 25/92] lavc/vaapi_encode_h265: fix
  max_transform_hierarchy_depth_inter/intra
 
 Set the max_transform_hierarchy_depth_inter/intra to 2 by default

--- a/patches/0026-lavc-vaapi_hevc-support-420-422-444-12bit-enc-dec.patch
+++ b/patches/0026-lavc-vaapi_hevc-support-420-422-444-12bit-enc-dec.patch
@@ -1,4 +1,4 @@
-From 49aae6f6a75b4f001c175d0e4eca3daeaa8d26a0 Mon Sep 17 00:00:00 2001
+From c94733e8207661436f1199f6ed56e2165203407f Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Tue, 14 Jul 2020 10:21:55 +0800
 Subject: [PATCH 26/92] lavc/vaapi_hevc: support 420/422/444 12bit enc/dec
@@ -17,7 +17,7 @@ Subject: [PATCH 26/92] lavc/vaapi_hevc: support 420/422/444 12bit enc/dec
  10 files changed, 166 insertions(+)
 
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index bbd1a687f7..afdb06a474 100644
+index bbd1a687f755..afdb06a47478 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -457,6 +457,11 @@ static enum AVPixelFormat get_format(HEVCContext *s, const HEVCSPS *sps)
@@ -33,7 +33,7 @@ index bbd1a687f7..afdb06a474 100644
          break;
      case AV_PIX_FMT_YUV420P12:
 diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
-index f722a9fd51..c6e3886b02 100644
+index f722a9fd5181..c6e3886b02be 100644
 --- a/libavcodec/vaapi_decode.c
 +++ b/libavcodec/vaapi_decode.c
 @@ -274,6 +274,15 @@ static const struct {
@@ -75,7 +75,7 @@ index f722a9fd51..c6e3886b02 100644
                                                  source_format, 0, NULL);
          if (format == best_format)
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 10d218d370..08dac7fb87 100644
+index 10d218d370a8..08dac7fb8727 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -1262,6 +1262,11 @@ static const VAAPIEncodeRTFormat vaapi_encode_rt_formats[] = {
@@ -91,7 +91,7 @@ index 10d218d370..08dac7fb87 100644
  
  static const VAEntrypoint vaapi_encode_entrypoints_normal[] = {
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index 3308be7d1e..5c37ed042c 100644
+index 3308be7d1ed6..5c37ed042c43 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -1155,7 +1155,11 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
@@ -107,7 +107,7 @@ index 3308be7d1e..5c37ed042c 100644
  };
  
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index 027612dc99..7d68861c1e 100644
+index 027612dc99df..7d68861c1ea9 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -569,6 +569,15 @@ VAProfile ff_vaapi_parse_hevc_rext_profile(AVCodecContext *avctx)
@@ -127,7 +127,7 @@ index 027612dc99..7d68861c1e 100644
      av_log(avctx, AV_LOG_WARNING, "HEVC profile %s is "
             "not supported with this VA version.\n", profile->name);
 diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
-index 5aa410c6cd..8423edb68f 100644
+index 5aa410c6cd13..8423edb68f57 100644
 --- a/libavutil/hwcontext_vaapi.c
 +++ b/libavutil/hwcontext_vaapi.c
 @@ -129,6 +129,15 @@ static const VAAPIFormatDescriptor vaapi_format_map[] = {
@@ -147,7 +147,7 @@ index 5aa410c6cd..8423edb68f 100644
      MAP(BGRA, RGB32,   BGRA, 0),
      MAP(BGRX, RGB32,   BGR0, 0),
 diff --git a/libavutil/pixdesc.c b/libavutil/pixdesc.c
-index 136a4f82a2..accf8a58cf 100644
+index 136a4f82a271..accf8a58cf11 100644
 --- a/libavutil/pixdesc.c
 +++ b/libavutil/pixdesc.c
 @@ -224,6 +224,29 @@ static const AVPixFmtDescriptor av_pix_fmt_descriptors[AV_PIX_FMT_NB] = {
@@ -245,7 +245,7 @@ index 136a4f82a2..accf8a58cf 100644
          .name = "p016le",
          .nb_components = 3,
 diff --git a/libavutil/pixfmt.h b/libavutil/pixfmt.h
-index 184ded7e85..d359f4e752 100644
+index 184ded7e8530..d359f4e752c1 100644
 --- a/libavutil/pixfmt.h
 +++ b/libavutil/pixfmt.h
 @@ -287,6 +287,8 @@ enum AVPixelFormat {
@@ -289,7 +289,7 @@ index 184ded7e85..d359f4e752 100644
  #define AV_PIX_FMT_X2BGR10    AV_PIX_FMT_NE(X2BGR10BE, X2BGR10LE)
  
 diff --git a/tests/ref/fate/imgutils b/tests/ref/fate/imgutils
-index 290e87c2d9..7aff0e462e 100644
+index 290e87c2d9e8..7aff0e462e2d 100644
 --- a/tests/ref/fate/imgutils
 +++ b/tests/ref/fate/imgutils
 @@ -214,6 +214,8 @@ gray12be        planes: 1, linesizes: 128   0   0   0, plane_sizes:  6144     0
@@ -316,7 +316,7 @@ index 290e87c2d9..7aff0e462e 100644
  x2rgb10be       planes: 1, linesizes: 256   0   0   0, plane_sizes: 12288     0     0     0, plane_offsets:     0     0     0, total_size: 12288
  x2bgr10le       planes: 1, linesizes: 256   0   0   0, plane_sizes: 12288     0     0     0, plane_offsets:     0     0     0, total_size: 12288
 diff --git a/tests/ref/fate/sws-pixdesc-query b/tests/ref/fate/sws-pixdesc-query
-index 7613ba7524..68769b210c 100644
+index 7613ba75246f..68769b210c6c 100644
 --- a/tests/ref/fate/sws-pixdesc-query
 +++ b/tests/ref/fate/sws-pixdesc-query
 @@ -57,6 +57,8 @@ isNBPS:
@@ -431,5 +431,5 @@ index 7613ba7524..68769b210c 100644
    p016le
    yuv410p
 -- 
-2.25.1
+2.25.4
 

--- a/patches/0027-lavc-vaapi_vp9-support-420-444-12bit-dec.patch
+++ b/patches/0027-lavc-vaapi_vp9-support-420-444-12bit-dec.patch
@@ -1,4 +1,4 @@
-From 9fac33f922536f1628d2b5c3f74d9d7d854a232b Mon Sep 17 00:00:00 2001
+From aaec5088eb79794a5c580766747bf87cc093ed94 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Mon, 11 May 2020 14:26:18 +0800
 Subject: [PATCH 27/92] lavc/vaapi_vp9: support 420/444 12bit dec
@@ -13,7 +13,7 @@ ffmpeg -hwaccel vaapi -hwaccel_device /dev/dri/renderD128 -v debug -i colorbar_4
  1 file changed, 7 insertions(+)
 
 diff --git a/libavcodec/vp9.c b/libavcodec/vp9.c
-index 6ed16b62cd..45f1ff61af 100644
+index 619dd1bfea59..ca4e1d08ee08 100644
 --- a/libavcodec/vp9.c
 +++ b/libavcodec/vp9.c
 @@ -231,6 +231,13 @@ static int update_size(AVCodecContext *avctx, int w, int h)
@@ -31,5 +31,5 @@ index 6ed16b62cd..45f1ff61af 100644
  
          *fmtp++ = s->pix_fmt;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0028-lavc-qsv-support-hevc-vp9-12bit.patch
+++ b/patches/0028-lavc-qsv-support-hevc-vp9-12bit.patch
@@ -1,4 +1,4 @@
-From fcea5ce3e8db53a13ca27fe1462b915715a5d0cd Mon Sep 17 00:00:00 2001
+From b843b4f8f923719f235b36f92e6274a83833e58c Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 28 May 2020 14:14:32 -0400
 Subject: [PATCH 28/92] lavc/qsv: support hevc/vp9 12bit
@@ -20,7 +20,7 @@ ffmpeg -init_hw_device qsv=qsv:hw -hwaccel qsv -filter_hw_device qsv -v verbose 
  2 files changed, 35 insertions(+)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 10a06d59a7..bbae639983 100644
+index 47dec181a153..b9deb6b1a629 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -198,6 +198,11 @@ enum AVPixelFormat ff_qsv_map_fourcc(uint32_t fourcc)
@@ -57,7 +57,7 @@ index 10a06d59a7..bbae639983 100644
      default:
          return AVERROR(ENOSYS);
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index dd72efe009..8acc9d62ff 100644
+index 362108e26aab..16966016710d 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -113,6 +113,14 @@ static const struct {
@@ -75,7 +75,7 @@ index dd72efe009..8acc9d62ff 100644
  #endif
  };
  
-@@ -905,6 +913,7 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
+@@ -909,6 +917,7 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
      switch (frame->format) {
      case AV_PIX_FMT_NV12:
      case AV_PIX_FMT_P010:
@@ -83,7 +83,7 @@ index dd72efe009..8acc9d62ff 100644
          surface->Data.Y  = frame->data[0];
          surface->Data.UV = frame->data[1];
          break;
-@@ -929,6 +938,7 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
+@@ -933,6 +942,7 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
          break;
  
      case AV_PIX_FMT_Y210:
@@ -91,7 +91,7 @@ index dd72efe009..8acc9d62ff 100644
          surface->Data.Y16 = (mfxU16 *)frame->data[0];
          surface->Data.U16 = (mfxU16 *)frame->data[0] + 1;
          surface->Data.V16 = (mfxU16 *)frame->data[0] + 3;
-@@ -942,6 +952,12 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
+@@ -946,6 +956,12 @@ static int map_frame_to_surface(const AVFrame *frame, mfxFrameSurface1 *surface)
      case AV_PIX_FMT_Y410:
          surface->Data.U = frame->data[0];
          break;
@@ -105,5 +105,5 @@ index dd72efe009..8acc9d62ff 100644
      default:
          return MFX_ERR_UNSUPPORTED;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0029-avfilter-add-overlay-vaapi-filter.patch
+++ b/patches/0029-avfilter-add-overlay-vaapi-filter.patch
@@ -1,4 +1,4 @@
-From 6e0f319c881cfacfad48f19d75571e6f022d8480 Mon Sep 17 00:00:00 2001
+From 09eecea6824270397e029eeb4b6f6ddb034b016e Mon Sep 17 00:00:00 2001
 From: Xinpeng Sun <xinpeng.sun@intel.com>
 Date: Wed, 26 Feb 2020 13:53:34 +0800
 Subject: [PATCH 29/92] avfilter: add overlay vaapi filter
@@ -28,7 +28,7 @@ Signed-off-by: Zachary Zhou <zachary.zhou@intel.com>
  create mode 100644 libavfilter/vf_overlay_vaapi.c
 
 diff --git a/configure b/configure
-index af410a9d11..dc71dbc288 100755
+index 231d0398a87a..9a4841b8b1db 100755
 --- a/configure
 +++ b/configure
 @@ -3624,6 +3624,7 @@ openclsrc_filter_deps="opencl"
@@ -47,7 +47,7 @@ index af410a9d11..dc71dbc288 100755
  unsharp_opencl_filter_deps="opencl"
  uspp_filter_deps="gpl avcodec"
  vaguedenoiser_filter_deps="gpl"
-@@ -6757,6 +6759,7 @@ if enabled vaapi; then
+@@ -6761,6 +6763,7 @@ if enabled vaapi; then
      check_struct "va/va.h" "VADecPictureParameterBufferAV1" bit_depth_idx
      check_type   "va/va.h va/va_vpp.h" "VAProcFilterParameterBufferHDRToneMapping"
      check_struct "va/va.h va/va_vpp.h" "VAProcPipelineCaps" rotation_flags
@@ -56,10 +56,10 @@ index af410a9d11..dc71dbc288 100755
      check_type "va/va.h va/va_enc_jpeg.h" "VAEncPictureParameterBufferJPEG"
      check_type "va/va.h va/va_enc_vp8.h"  "VAEncPictureParameterBufferVP8"
 diff --git a/doc/filters.texi b/doc/filters.texi
-index 9ad6031d23..b08d3a5624 100644
+index 1994467f460b..d1aebc287210 100644
 --- a/doc/filters.texi
 +++ b/doc/filters.texi
-@@ -24114,6 +24114,57 @@ To enable compilation of these filters you need to configure FFmpeg with
+@@ -24296,6 +24296,57 @@ To enable compilation of these filters you need to configure FFmpeg with
  
  To use vaapi filters, you need to setup the vaapi device correctly. For more information, please read @url{https://trac.ffmpeg.org/wiki/Hardware/VAAPI}
  
@@ -118,10 +118,10 @@ index 9ad6031d23..b08d3a5624 100644
  
  Perform HDR(High Dynamic Range) to SDR(Standard Dynamic Range) conversion with tone-mapping.
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index af957a5ac0..2bb7c43591 100644
+index dbd86857912d..24b8eddfe2b1 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
-@@ -361,6 +361,7 @@ OBJS-$(CONFIG_OVERLAY_CUDA_FILTER)           += vf_overlay_cuda.o framesync.o vf
+@@ -365,6 +365,7 @@ OBJS-$(CONFIG_OVERLAY_CUDA_FILTER)           += vf_overlay_cuda.o framesync.o vf
  OBJS-$(CONFIG_OVERLAY_OPENCL_FILTER)         += vf_overlay_opencl.o opencl.o \
                                                  opencl/overlay.o framesync.o
  OBJS-$(CONFIG_OVERLAY_QSV_FILTER)            += vf_overlay_qsv.o framesync.o
@@ -130,10 +130,10 @@ index af957a5ac0..2bb7c43591 100644
  OBJS-$(CONFIG_OWDENOISE_FILTER)              += vf_owdenoise.o
  OBJS-$(CONFIG_PAD_FILTER)                    += vf_pad.o
 diff --git a/libavfilter/allfilters.c b/libavfilter/allfilters.c
-index 0c6b2347c8..6a81dbe70d 100644
+index 761c2610054a..27afdb7b8473 100644
 --- a/libavfilter/allfilters.c
 +++ b/libavfilter/allfilters.c
-@@ -344,6 +344,7 @@ extern const AVFilter ff_vf_oscilloscope;
+@@ -348,6 +348,7 @@ extern const AVFilter ff_vf_oscilloscope;
  extern const AVFilter ff_vf_overlay;
  extern const AVFilter ff_vf_overlay_opencl;
  extern const AVFilter ff_vf_overlay_qsv;
@@ -143,7 +143,7 @@ index 0c6b2347c8..6a81dbe70d 100644
  extern const AVFilter ff_vf_owdenoise;
 diff --git a/libavfilter/vf_overlay_vaapi.c b/libavfilter/vf_overlay_vaapi.c
 new file mode 100644
-index 0000000000..e0e583525d
+index 000000000000..b369fcc41bc3
 --- /dev/null
 +++ b/libavfilter/vf_overlay_vaapi.c
 @@ -0,0 +1,424 @@
@@ -565,12 +565,12 @@ index 0000000000..e0e583525d
 +    .priv_class      = &overlay_vaapi_class,
 +    .init            = &overlay_vaapi_init,
 +    .uninit          = &overlay_vaapi_uninit,
-+    .query_formats   = &overlay_vaapi_query_formats,
 +    .activate        = &overlay_vaapi_activate,
 +    FILTER_INPUTS(overlay_vaapi_inputs),
 +    FILTER_OUTPUTS(overlay_vaapi_outputs),
++    FILTER_QUERY_FUNC(overlay_vaapi_query_formats),
 +    .flags_internal  = FF_FILTER_FLAG_HWFRAME_AWARE,
 +};
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0030-avfilter-tonemap_vaapi-pass-filter-parameters-to-VA-.patch
+++ b/patches/0030-avfilter-tonemap_vaapi-pass-filter-parameters-to-VA-.patch
@@ -1,4 +1,4 @@
-From 6ae9299515efa248cbaf696b9dad18a5a6724211 Mon Sep 17 00:00:00 2001
+From 28f42e4bc6cdb23131c72eb9ea368a332301d839 Mon Sep 17 00:00:00 2001
 From: Xinpeng Sun <xinpeng.sun@intel.com>
 Date: Fri, 17 Jan 2020 11:56:50 +0800
 Subject: [PATCH 30/92] avfilter/tonemap_vaapi: pass filter parameters to VA
@@ -10,7 +10,7 @@ Signed-off-by: Xinpeng Sun <xinpeng.sun@intel.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/libavfilter/vf_tonemap_vaapi.c b/libavfilter/vf_tonemap_vaapi.c
-index a5cf9b0d8d..4360d8e545 100644
+index 5a41f14d00d5..97bf1d8e0d4a 100644
 --- a/libavfilter/vf_tonemap_vaapi.c
 +++ b/libavfilter/vf_tonemap_vaapi.c
 @@ -294,6 +294,9 @@ static int tonemap_vaapi_filter_frame(AVFilterLink *inlink, AVFrame *input_frame
@@ -24,5 +24,5 @@ index a5cf9b0d8d..4360d8e545 100644
      if (err < 0)
          goto fail;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0031-avfilter-Add-H2H-support-in-tonemap_vaapi.patch
+++ b/patches/0031-avfilter-Add-H2H-support-in-tonemap_vaapi.patch
@@ -1,4 +1,4 @@
-From 0e827f2ba5ee4d44b4ef7b64ecb21fcd0780bab3 Mon Sep 17 00:00:00 2001
+From db93bc2e90efa01c8f175422438ffd63c560dcb8 Mon Sep 17 00:00:00 2001
 From: Xinpeng Sun <xinpeng.sun@intel.com>
 Date: Mon, 23 Dec 2019 15:29:32 +0800
 Subject: [PATCH 31/92] avfilter: Add H2H support in tonemap_vaapi
@@ -9,7 +9,7 @@ Signed-off-by: Xinpeng Sun <xinpeng.sun@intel.com>
  1 file changed, 181 insertions(+), 10 deletions(-)
 
 diff --git a/libavfilter/vf_tonemap_vaapi.c b/libavfilter/vf_tonemap_vaapi.c
-index 4360d8e545..f28f62acf8 100644
+index 97bf1d8e0d4a..23e9fdba8f3f 100644
 --- a/libavfilter/vf_tonemap_vaapi.c
 +++ b/libavfilter/vf_tonemap_vaapi.c
 @@ -39,7 +39,11 @@ typedef struct HDRVAAPIContext {
@@ -257,5 +257,5 @@ index 4360d8e545..f28f62acf8 100644
  
  static const AVFilterPad tonemap_vaapi_inputs[] = {
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0032-lavc-vaapi_hevc-add-skip_frame-invalid-to-skip-inval.patch
+++ b/patches/0032-lavc-vaapi_hevc-add-skip_frame-invalid-to-skip-inval.patch
@@ -1,4 +1,4 @@
-From 645126900783db78253503ec3ab9e7f3b2372707 Mon Sep 17 00:00:00 2001
+From 93448981cdfbe4a2be61c673fa9d0355ecf29eac Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 14 Jul 2020 14:56:25 +0800
 Subject: [PATCH 32/92] lavc/vaapi_hevc: add -skip_frame invalid to skip
@@ -21,7 +21,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  4 files changed, 8 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/defs.h b/libavcodec/defs.h
-index 420a042b8f..25052048b4 100644
+index 420a042b8ff4..25052048b4e0 100644
 --- a/libavcodec/defs.h
 +++ b/libavcodec/defs.h
 @@ -47,6 +47,7 @@ enum AVDiscard{
@@ -33,7 +33,7 @@ index 420a042b8f..25052048b4 100644
      AVDISCARD_BIDIR   = 16, ///< discard all bidirectional frames
      AVDISCARD_NONINTRA= 24, ///< discard all non intra frames
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index c3005876b4..fc3d0bebaa 100644
+index afdb06a47478..37c1c4de8a2e 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -568,8 +568,11 @@ static int hls_slice_header(HEVCContext *s)
@@ -58,10 +58,10 @@ index c3005876b4..fc3d0bebaa 100644
              break;
          }
 diff --git a/libavcodec/options_table.h b/libavcodec/options_table.h
-index ae42b65b7b..2fd6dcabf3 100644
+index 130341a2ec7b..e98c76a3e47a 100644
 --- a/libavcodec/options_table.h
 +++ b/libavcodec/options_table.h
-@@ -248,6 +248,7 @@ static const AVOption avcodec_options[] = {
+@@ -250,6 +250,7 @@ static const AVOption avcodec_options[] = {
  {"skip_frame"      , "skip decoding for the selected frames",               OFFSET(skip_frame),       AV_OPT_TYPE_INT, {.i64 = AVDISCARD_DEFAULT }, INT_MIN, INT_MAX, V|D, "avdiscard"},
  {"none"            , "discard no frame",                    0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_NONE    }, INT_MIN, INT_MAX, V|D, "avdiscard"},
  {"default"         , "discard useless frames",              0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_DEFAULT }, INT_MIN, INT_MAX, V|D, "avdiscard"},
@@ -70,7 +70,7 @@ index ae42b65b7b..2fd6dcabf3 100644
  {"bidir"           , "discard all bidirectional frames",    0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_BIDIR   }, INT_MIN, INT_MAX, V|D, "avdiscard"},
  {"nokey"           , "discard all frames except keyframes", 0, AV_OPT_TYPE_CONST, {.i64 = AVDISCARD_NONKEY  }, INT_MIN, INT_MAX, V|D, "avdiscard"},
 diff --git a/libavcodec/pthread_frame.c b/libavcodec/pthread_frame.c
-index 9c5d66c0d4..109808224d 100644
+index 73b1b7d7d97f..b2c0f672cb56 100644
 --- a/libavcodec/pthread_frame.c
 +++ b/libavcodec/pthread_frame.c
 @@ -278,6 +278,7 @@ static int update_context_from_thread(AVCodecContext *dst, AVCodecContext *src,
@@ -82,5 +82,5 @@ index 9c5d66c0d4..109808224d 100644
          dst->bits_per_coded_sample = src->bits_per_coded_sample;
          dst->sample_aspect_ratio   = src->sample_aspect_ratio;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0033-FFmpeg-vaapi-HEVC-SCC-encode.patch
+++ b/patches/0033-FFmpeg-vaapi-HEVC-SCC-encode.patch
@@ -1,4 +1,4 @@
-From 161c006fcb53f798bb1df7d19711cede6e32d5d5 Mon Sep 17 00:00:00 2001
+From daa0d2dfe67881663656b125ec71c9a6fd7c2bb4 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Sun, 18 Oct 2020 16:15:37 -0400
 Subject: [PATCH 33/92] FFmpeg vaapi HEVC SCC encode.
@@ -25,10 +25,10 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  3 files changed, 48 insertions(+), 10 deletions(-)
 
 diff --git a/libavcodec/avcodec.h b/libavcodec/avcodec.h
-index ffd58c333f..fa21a5ed6f 100644
+index 7ee8bc2b7cc0..9346c870524c 100644
 --- a/libavcodec/avcodec.h
 +++ b/libavcodec/avcodec.h
-@@ -1610,6 +1610,7 @@ typedef struct AVCodecContext {
+@@ -1614,6 +1614,7 @@ typedef struct AVCodecContext {
  #define FF_PROFILE_HEVC_MAIN_10                     2
  #define FF_PROFILE_HEVC_MAIN_STILL_PICTURE          3
  #define FF_PROFILE_HEVC_REXT                        4
@@ -37,7 +37,7 @@ index ffd58c333f..fa21a5ed6f 100644
  #define FF_PROFILE_VVC_MAIN_10                      1
  #define FF_PROFILE_VVC_MAIN_10_444                 33
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 313d4eeb65..5db8005555 100644
+index 08dac7fb8727..347cda4c0cc2 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -1256,6 +1256,7 @@ static const VAAPIEncodeRTFormat vaapi_encode_rt_formats[] = {
@@ -49,7 +49,7 @@ index 313d4eeb65..5db8005555 100644
      { "YUV444",    VA_RT_FORMAT_YUV444,        8, 3, 0, 0 },
      { "YUV411",    VA_RT_FORMAT_YUV411,        8, 3, 2, 0 },
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index 5c37ed042c..4d0ce87059 100644
+index 5c37ed042c43..4d0ce8705980 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -300,17 +300,13 @@ static int vaapi_encode_h265_init_sequence_params(AVCodecContext *avctx)
@@ -191,5 +191,5 @@ index 5c37ed042c..4d0ce87059 100644
  
      { "tier", "Set tier (general_tier_flag)",
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0034-lavc-qsvenc-add-support-for-Screen-Content-Coding-SC.patch
+++ b/patches/0034-lavc-qsvenc-add-support-for-Screen-Content-Coding-SC.patch
@@ -1,4 +1,4 @@
-From 5263c788d7d4ebfa7f3ecc574acb07a6cd8b98c7 Mon Sep 17 00:00:00 2001
+From ca760472fd06a7cd335a7030b06f01e9fa40d006 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Mon, 28 Sep 2020 14:14:42 +0800
 Subject: [PATCH 34/92] lavc/qsvenc: add support for Screen Content Coding
@@ -16,7 +16,7 @@ ffmpeg -init_hw_device qsv=qsv:hw -f lavfi -i testsrc -vf \
  2 files changed, 6 insertions(+)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 6c0f622995..2fc11ce7a1 100644
+index 032393b86bef..680da8a36f26 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -69,6 +69,9 @@ static const struct {
@@ -30,7 +30,7 @@ index 6c0f622995..2fc11ce7a1 100644
  
  static const char *print_profile(mfxU16 profile)
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index b7b2f5633e..ced9fe026f 100644
+index b7b2f5633ef7..ced9fe026f4f 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -241,6 +241,9 @@ static const AVOption options[] = {
@@ -44,5 +44,5 @@ index b7b2f5633e..ced9fe026f 100644
      { "gpb", "1: GPB (generalized P/B frame); 0: regular P frame", OFFSET(qsv.gpb), AV_OPT_TYPE_BOOL, { .i64 = 1 }, 0, 1, VE},
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0035-lavc-avcodec-Add-FF_PROFILE_HEVC_SCC-for-screen-cont.patch
+++ b/patches/0035-lavc-avcodec-Add-FF_PROFILE_HEVC_SCC-for-screen-cont.patch
@@ -1,4 +1,4 @@
-From db7c689fc3e0c8af3996129a0ae84e6ac1d486f0 Mon Sep 17 00:00:00 2001
+From 102e855a19d3bf7a8f16d0780a8132474ea522c1 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:39 +0800
 Subject: [PATCH 35/92] lavc/avcodec: Add FF_PROFILE_HEVC_SCC for screen
@@ -11,7 +11,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  2 files changed, 3 insertions(+)
 
 diff --git a/libavcodec/hevc_ps.c b/libavcodec/hevc_ps.c
-index 764c4849ee..3dffb51f09 100644
+index 764c4849eeab..3dffb51f096b 100644
 --- a/libavcodec/hevc_ps.c
 +++ b/libavcodec/hevc_ps.c
 @@ -281,6 +281,8 @@ static int decode_profile_tier_level(GetBitContext *gb, AVCodecContext *avctx,
@@ -24,7 +24,7 @@ index 764c4849ee..3dffb51f09 100644
          av_log(avctx, AV_LOG_WARNING, "Unknown HEVC profile: %d\n", ptl->profile_idc);
  
 diff --git a/libavcodec/profiles.c b/libavcodec/profiles.c
-index 7af7fbeb13..2230fc5415 100644
+index 7af7fbeb1302..2230fc5415d0 100644
 --- a/libavcodec/profiles.c
 +++ b/libavcodec/profiles.c
 @@ -85,6 +85,7 @@ const AVProfile ff_hevc_profiles[] = {
@@ -36,5 +36,5 @@ index 7af7fbeb13..2230fc5415 100644
  };
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0036-lavc-hevc_ps-Add-sps-parse-support-for-HEVC-SCC-exte.patch
+++ b/patches/0036-lavc-hevc_ps-Add-sps-parse-support-for-HEVC-SCC-exte.patch
@@ -1,4 +1,4 @@
-From 1837f47dd1ab3d16a618f23746b1e921b4261939 Mon Sep 17 00:00:00 2001
+From 50678ccfc17489139e3e58754b0640ecb0ad9ecd Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:40 +0800
 Subject: [PATCH 36/92] lavc/hevc_ps: Add sps parse support for HEVC SCC
@@ -15,7 +15,7 @@ Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
  3 files changed, 59 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/hevc.h b/libavcodec/hevc.h
-index 1804755327..6b454a75c1 100644
+index 1804755327e1..6b454a75c188 100644
 --- a/libavcodec/hevc.h
 +++ b/libavcodec/hevc.h
 @@ -154,6 +154,9 @@ enum {
@@ -29,7 +29,7 @@ index 1804755327..6b454a75c1 100644
  
  
 diff --git a/libavcodec/hevc_ps.c b/libavcodec/hevc_ps.c
-index 3dffb51f09..7e72acc2e9 100644
+index 3dffb51f096b..7e72acc2e950 100644
 --- a/libavcodec/hevc_ps.c
 +++ b/libavcodec/hevc_ps.c
 @@ -913,7 +913,7 @@ int ff_hevc_parse_sps(HEVCSPS *sps, GetBitContext *gb, unsigned int *sps_id,
@@ -98,7 +98,7 @@ index 3dffb51f09..7e72acc2e9 100644
      if (apply_defdispwin) {
          sps->output_window.left_offset   += sps->vui.def_disp_win.left_offset;
 diff --git a/libavcodec/hevc_ps.h b/libavcodec/hevc_ps.h
-index 2a1bbf6489..be23758008 100644
+index 2a1bbf64899f..be237580083f 100644
 --- a/libavcodec/hevc_ps.h
 +++ b/libavcodec/hevc_ps.h
 @@ -223,6 +223,21 @@ typedef struct HEVCSPS {
@@ -124,5 +124,5 @@ index 2a1bbf6489..be23758008 100644
      int width;
      int height;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0037-lavc-hevc_ps-Add-pps-parse-support-for-HEVC-SCC-exte.patch
+++ b/patches/0037-lavc-hevc_ps-Add-pps-parse-support-for-HEVC-SCC-exte.patch
@@ -1,4 +1,4 @@
-From 55c768c8120df3caeb3424289259a8b1bfd52cef Mon Sep 17 00:00:00 2001
+From 4eee6813d934ad0b63cd57b8e6cae0cd33a77571 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:41 +0800
 Subject: [PATCH 37/92] lavc/hevc_ps: Add pps parse support for HEVC SCC
@@ -12,7 +12,7 @@ Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
  2 files changed, 86 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/hevc_ps.c b/libavcodec/hevc_ps.c
-index 7e72acc2e9..460a392358 100644
+index 7e72acc2e950..460a39235865 100644
 --- a/libavcodec/hevc_ps.c
 +++ b/libavcodec/hevc_ps.c
 @@ -1404,6 +1404,48 @@ static int pps_range_extensions(GetBitContext *gb, AVCodecContext *avctx,
@@ -104,7 +104,7 @@ index 7e72acc2e9..460a392358 100644
  
      ret = setup_pps(avctx, gb, pps, sps);
 diff --git a/libavcodec/hevc_ps.h b/libavcodec/hevc_ps.h
-index be23758008..155b66062e 100644
+index be237580083f..155b66062e78 100644
 --- a/libavcodec/hevc_ps.h
 +++ b/libavcodec/hevc_ps.h
 @@ -312,6 +312,9 @@ typedef struct HEVCPPS {
@@ -139,5 +139,5 @@ index be23758008..155b66062e 100644
      unsigned int *column_width;  ///< ColumnWidth
      unsigned int *row_height;    ///< RowHeight
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0038-lavc-hevc_ps-Add-slice-parse-support-for-HEVC-SCC-ex.patch
+++ b/patches/0038-lavc-hevc_ps-Add-slice-parse-support-for-HEVC-SCC-ex.patch
@@ -1,4 +1,4 @@
-From b4297385a022b323eb29556a335d48f76f3cc5aa Mon Sep 17 00:00:00 2001
+From dd435b1dc2503f9945efdbe3c4bb563b38191133 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:42 +0800
 Subject: [PATCH 38/92] lavc/hevc_ps: Add slice parse support for HEVC SCC
@@ -11,7 +11,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  2 files changed, 10 insertions(+)
 
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index fc3d0bebaa..a36af3e8a0 100644
+index 37c1c4de8a2e..1ae24026fc50 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -840,6 +840,12 @@ static int hls_slice_header(HEVCContext *s)
@@ -28,7 +28,7 @@ index fc3d0bebaa..a36af3e8a0 100644
              sh->cu_chroma_qp_offset_enabled_flag = get_bits1(gb);
          else
 diff --git a/libavcodec/hevcdec.h b/libavcodec/hevcdec.h
-index e738a7b063..f3e311bd40 100644
+index e738a7b063a2..f3e311bd4092 100644
 --- a/libavcodec/hevcdec.h
 +++ b/libavcodec/hevcdec.h
 @@ -293,6 +293,10 @@ typedef struct SliceHeader {
@@ -43,5 +43,5 @@ index e738a7b063..f3e311bd40 100644
  
      int beta_offset;    ///< beta_offset_div2 * 2
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0039-lavc-hevcdec-Fix-the-parsing-for-use_integer_mv_flag.patch
+++ b/patches/0039-lavc-hevcdec-Fix-the-parsing-for-use_integer_mv_flag.patch
@@ -1,4 +1,4 @@
-From 13f6135c446f64bf5bfbfc8e3a8f5fb834e47696 Mon Sep 17 00:00:00 2001
+From 901445cbf9f6915ca9bed7a367bc74a708794f4e Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:43 +0800
 Subject: [PATCH 39/92] lavc/hevcdec: Fix the parsing for use_integer_mv_flag
@@ -16,7 +16,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  2 files changed, 9 insertions(+)
 
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index a36af3e8a0..bc609f54ca 100644
+index 1ae24026fc50..80a679788abd 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -823,6 +823,14 @@ static int hls_slice_header(HEVCContext *s)
@@ -35,7 +35,7 @@ index a36af3e8a0..bc609f54ca 100644
  
          sh->slice_qp_delta = get_se_golomb(gb);
 diff --git a/libavcodec/hevcdec.h b/libavcodec/hevcdec.h
-index f3e311bd40..3dbf54adfa 100644
+index f3e311bd4092..3dbf54adfa60 100644
 --- a/libavcodec/hevcdec.h
 +++ b/libavcodec/hevcdec.h
 @@ -303,6 +303,7 @@ typedef struct SliceHeader {
@@ -47,5 +47,5 @@ index f3e311bd40..3dbf54adfa 100644
      unsigned *entry_point_offset;
      int * offset;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0040-lavc-hevcdec-Set-max_num_merge_cand-to-uint8_t.patch
+++ b/patches/0040-lavc-hevcdec-Set-max_num_merge_cand-to-uint8_t.patch
@@ -1,4 +1,4 @@
-From 178cd9bfbfdb87a4771d0e79333cbc1d7acd7e9a Mon Sep 17 00:00:00 2001
+From 5c14cdfd6f4ab70434044a07bee9b7ec317e7326 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:44 +0800
 Subject: [PATCH 40/92] lavc/hevcdec: Set max_num_merge_cand to uint8_t
@@ -12,7 +12,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/hevcdec.h b/libavcodec/hevcdec.h
-index 3dbf54adfa..8677fcca1e 100644
+index 3dbf54adfa60..8677fcca1e4f 100644
 --- a/libavcodec/hevcdec.h
 +++ b/libavcodec/hevcdec.h
 @@ -302,7 +302,7 @@ typedef struct SliceHeader {
@@ -25,5 +25,5 @@ index 3dbf54adfa..8677fcca1e 100644
  
      unsigned *entry_point_offset;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0041-lavc-hevc-Update-reference-list-for-SCC.patch
+++ b/patches/0041-lavc-hevc-Update-reference-list-for-SCC.patch
@@ -1,4 +1,4 @@
-From 5df70cf2d909e6570d2c8807abafcf540bc10cf8 Mon Sep 17 00:00:00 2001
+From 1b6e66941e4d69736af0646b41ba9b8d93251000 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:45 +0800
 Subject: [PATCH 41/92] lavc/hevc: Update reference list for SCC
@@ -17,7 +17,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  2 files changed, 27 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/hevc_refs.c b/libavcodec/hevc_refs.c
-index f78a690b25..e6054696a3 100644
+index f78a690b2500..e6054696a337 100644
 --- a/libavcodec/hevc_refs.c
 +++ b/libavcodec/hevc_refs.c
 @@ -315,7 +315,7 @@ int ff_hevc_slice_rpl(HEVCContext *s)
@@ -89,7 +89,7 @@ index f78a690b25..e6054696a3 100644
      return ret;
  }
 diff --git a/libavcodec/hevcdec.c b/libavcodec/hevcdec.c
-index bc609f54ca..e08c0c0e42 100644
+index 80a679788abd..3025fd6511b4 100644
 --- a/libavcodec/hevcdec.c
 +++ b/libavcodec/hevcdec.c
 @@ -652,7 +652,8 @@ static int hls_slice_header(HEVCContext *s)
@@ -103,5 +103,5 @@ index bc609f54ca..e08c0c0e42 100644
              return AVERROR_INVALIDDATA;
          }
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0042-lavc-vaapi_hevc-Pass-SCC-parameters-Through-VA-API.patch
+++ b/patches/0042-lavc-vaapi_hevc-Pass-SCC-parameters-Through-VA-API.patch
@@ -1,4 +1,4 @@
-From 9c990d8b2eb54df766bcdad29707442df9e26dc8 Mon Sep 17 00:00:00 2001
+From e7476deaeb03198024783a392077a2571511a129 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Fri, 5 Jun 2020 13:36:41 +0800
 Subject: [PATCH 42/92] lavc/vaapi_hevc: Pass SCC parameters Through VA-API
@@ -11,7 +11,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  1 file changed, 35 insertions(+), 5 deletions(-)
 
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index 7d68861c1e..4e3ae6cf3b 100644
+index 7d68861c1ea9..4e3ae6cf3b4c 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -124,7 +124,7 @@ static int vaapi_hevc_start_frame(AVCodecContext          *avctx,
@@ -95,5 +95,5 @@ index 7d68861c1e..4e3ae6cf3b 100644
          for (i = 0; i < 15 && i < sh->nb_refs[L0]; i++) {
              pic->last_slice_param.rext.luma_offset_l0[i] = sh->luma_offset_l0[i];
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0043-lavc-vaapi_hevc-Add-vaapi-profile-parse-support-for-.patch
+++ b/patches/0043-lavc-vaapi_hevc-Add-vaapi-profile-parse-support-for-.patch
@@ -1,4 +1,4 @@
-From 8b5eab292fd45c351de9055e7621a93fbd91c3dd Mon Sep 17 00:00:00 2001
+From 83e5ce80a14a375dda8581424bd5881fa829d240 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Tue, 2 Jun 2020 14:34:00 +0800
 Subject: [PATCH 43/92] lavc/vaapi_hevc: Add vaapi profile parse support for
@@ -15,7 +15,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  2 files changed, 12 insertions(+)
 
 diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
-index c6e3886b02..8026e0411f 100644
+index c6e3886b02be..8026e0411f2f 100644
 --- a/libavcodec/vaapi_decode.c
 +++ b/libavcodec/vaapi_decode.c
 @@ -416,6 +416,8 @@ static const struct {
@@ -28,7 +28,7 @@ index c6e3886b02..8026e0411f 100644
      MAP(MJPEG,       MJPEG_HUFFMAN_BASELINE_DCT,
                                        JPEGBaseline),
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index 4e3ae6cf3b..28fe76c40e 100644
+index 4e3ae6cf3b4c..28fe76c40e09 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -608,6 +608,16 @@ VAProfile ff_vaapi_parse_hevc_rext_profile(AVCodecContext *avctx)
@@ -49,5 +49,5 @@ index 4e3ae6cf3b..28fe76c40e 100644
      av_log(avctx, AV_LOG_WARNING, "HEVC profile %s is "
             "not supported with this VA version.\n", profile->name);
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0044-lavc-vaapi_hevc-Set-correct-rps-type-for-scc.patch
+++ b/patches/0044-lavc-vaapi_hevc-Set-correct-rps-type-for-scc.patch
@@ -1,4 +1,4 @@
-From b47049c5f3da2a175f1499c13baec3ec39508f0d Mon Sep 17 00:00:00 2001
+From 8605e4907964d83683651ea35d1a359a96cff45e Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 16 Jul 2020 17:08:52 +0800
 Subject: [PATCH 44/92] lavc/vaapi_hevc: Set correct rps type for scc
@@ -11,7 +11,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index 28fe76c40e..fb9cee36bd 100644
+index 28fe76c40e09..fb9cee36bd4b 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -88,6 +88,9 @@ static int find_frame_rps_type(const HEVCContext *h, const HEVCFrame *pic)
@@ -25,5 +25,5 @@ index 28fe76c40e..fb9cee36bd 100644
  }
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0045-lavc-vaapi_hevc-Loose-the-restricts-for-SCC-decoding.patch
+++ b/patches/0045-lavc-vaapi_hevc-Loose-the-restricts-for-SCC-decoding.patch
@@ -1,4 +1,4 @@
-From 829fc667e81f61687dbd5d63a089bf37cb668104 Mon Sep 17 00:00:00 2001
+From 16d489865742562092aed0731a8510443fd635db Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Wed, 8 Jul 2020 17:27:48 +0800
 Subject: [PATCH 45/92] lavc/vaapi_hevc: Loose the restricts for SCC decoding
@@ -13,7 +13,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  1 file changed, 5 insertions(+), 5 deletions(-)
 
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index fb9cee36bd..1fc26590fd 100644
+index fb9cee36bd4b..1fc26590fdfe 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -103,7 +103,8 @@ static void fill_vaapi_reference_frames(const HEVCContext *h, VAPictureParameter
@@ -48,5 +48,5 @@ index fb9cee36bd..1fc26590fd 100644
  
      slice_param->luma_log2_weight_denom = sh->luma_log2_weight_denom;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0046-lavc-vaapi_hevc-Fill-rext-luma-chroma-offset.patch
+++ b/patches/0046-lavc-vaapi_hevc-Fill-rext-luma-chroma-offset.patch
@@ -1,4 +1,4 @@
-From 7978901b27a1e6a15bcce8e96a8d42554a4c7516 Mon Sep 17 00:00:00 2001
+From 36dd3abb40b3a5e6804c8ca45a8b8931c7b3cbbe Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Thu, 9 Jul 2020 15:10:54 +0800
 Subject: [PATCH 46/92] lavc/vaapi_hevc: Fill rext luma/chroma offset
@@ -13,7 +13,7 @@ Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
  1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index 1fc26590fd..cb9db53539 100644
+index 1fc26590fdfe..cb9db53539f1 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -360,7 +360,7 @@ static void fill_pred_weight_table(const AVCodecContext *avctx,
@@ -47,5 +47,5 @@ index 1fc26590fd..cb9db53539 100644
              for (i = 0; i < 15 && i < sh->nb_refs[L1]; i++) {
                  pic->last_slice_param.rext.luma_offset_l1[i] = sh->luma_offset_l1[i];
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0047-lavc-hevc_refs-refine-ref-picture-lists-construction.patch
+++ b/patches/0047-lavc-hevc_refs-refine-ref-picture-lists-construction.patch
@@ -1,4 +1,4 @@
-From f34e57bd0c512df3f4d59bbd5525a7b0d26a30cd Mon Sep 17 00:00:00 2001
+From c5ba74fabe2931ce3697265e8a8760befe2bcf46 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Mon, 9 Nov 2020 10:39:08 -0500
 Subject: [PATCH 47/92] lavc/hevc_refs: refine ref picture lists construction
@@ -14,7 +14,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 6 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/hevc_refs.c b/libavcodec/hevc_refs.c
-index e6054696a3..51f72cd35f 100644
+index e6054696a337..51f72cd35fde 100644
 --- a/libavcodec/hevc_refs.c
 +++ b/libavcodec/hevc_refs.c
 @@ -344,6 +344,7 @@ int ff_hevc_slice_rpl(HEVCContext *s)
@@ -41,5 +41,5 @@ index e6054696a3..51f72cd35f 100644
  
          if (sh->collocated_list == list_idx &&
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0048-lavc-hevc_ps-remove-profile-limitation-when-excute-p.patch
+++ b/patches/0048-lavc-hevc_ps-remove-profile-limitation-when-excute-p.patch
@@ -1,4 +1,4 @@
-From b15850d967224b1ba01a076959638b3926961658 Mon Sep 17 00:00:00 2001
+From bb2229918b5ad7fe0d4e1d3f6503dab00bf54549 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Tue, 10 Nov 2020 15:19:39 -0500
 Subject: [PATCH 48/92] lavc/hevc_ps: remove profile limitation when excute
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  2 files changed, 26 insertions(+), 26 deletions(-)
 
 diff --git a/libavcodec/hevc_ps.c b/libavcodec/hevc_ps.c
-index 460a392358..5eaa0a4c02 100644
+index 460a39235865..5eaa0a4c02a6 100644
 --- a/libavcodec/hevc_ps.c
 +++ b/libavcodec/hevc_ps.c
 @@ -1814,7 +1814,7 @@ int ff_hevc_decode_nal_pps(GetBitContext *gb, AVCodecContext *avctx,
@@ -26,7 +26,7 @@ index 460a392358..5eaa0a4c02 100644
                  goto err;
          }
 diff --git a/tests/ref/fate/hevc-conformance-PS_A_VIDYO_3 b/tests/ref/fate/hevc-conformance-PS_A_VIDYO_3
-index 59b82b72bb..d1d86b2dc9 100644
+index 59b82b72bb56..d1d86b2dc9d4 100644
 --- a/tests/ref/fate/hevc-conformance-PS_A_VIDYO_3
 +++ b/tests/ref/fate/hevc-conformance-PS_A_VIDYO_3
 @@ -3,28 +3,28 @@
@@ -84,5 +84,5 @@ index 59b82b72bb..d1d86b2dc9 100644
 +0,         23,         23,        1,   149760, 0xf455f752
 +0,         24,         24,        1,   149760, 0x569fec99
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0049-lavc-vaapi_hevc-improve-scc-decode-pass-rate.patch
+++ b/patches/0049-lavc-vaapi_hevc-improve-scc-decode-pass-rate.patch
@@ -1,4 +1,4 @@
-From 45ffc2b35dacb45564903cf23585561294874cf5 Mon Sep 17 00:00:00 2001
+From e492ff7035e922b4bb8fac6aad3033b545068e0b Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Tue, 10 Nov 2020 15:31:18 -0500
 Subject: [PATCH 49/92] lavc/vaapi_hevc: improve scc decode pass rate
@@ -14,7 +14,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 23 insertions(+), 9 deletions(-)
 
 diff --git a/libavcodec/vaapi_hevc.c b/libavcodec/vaapi_hevc.c
-index cb9db53539..4c46f8d892 100644
+index cb9db53539f1..4c46f8d892e5 100644
 --- a/libavcodec/vaapi_hevc.c
 +++ b/libavcodec/vaapi_hevc.c
 @@ -128,7 +128,7 @@ static int vaapi_hevc_start_frame(AVCodecContext          *avctx,
@@ -89,5 +89,5 @@ index cb9db53539..4c46f8d892 100644
  #if VA_CHECK_VERSION(1, 8, 0)
      else if (!strcmp(profile->name, "Screen-Extended Main 4:4:4 10"))
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0050-lavc-vaapi_encode_h265-set-low-delay-B-automatically.patch
+++ b/patches/0050-lavc-vaapi_encode_h265-set-low-delay-B-automatically.patch
@@ -1,4 +1,4 @@
-From 73372b0e991f08b114b7c2e70d2d84b3e491c824 Mon Sep 17 00:00:00 2001
+From 3989a01cf93c38f3fb7047c1358f88f50bc6d209 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Wed, 25 Nov 2020 13:48:35 -0500
 Subject: [PATCH 50/92] lavc/vaapi_encode_h265: set low delay B automatically
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  2 files changed, 31 insertions(+), 22 deletions(-)
 
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index 5db8005555..c3ff2544b2 100644
+index 347cda4c0cc2..113773e5e7f1 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -1908,6 +1908,30 @@ static av_cold int vaapi_encode_init_gop_structure(AVCodecContext *avctx)
@@ -66,7 +66,7 @@ index 5db8005555..c3ff2544b2 100644
                     "B-frames (supported references: %d / %d).\n",
                     ref_l0, ref_l1);
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index 4d0ce87059..b7ddcf13e7 100644
+index 4d0ce8705980..b7ddcf13e7dd 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -936,8 +936,7 @@ static int vaapi_encode_h265_init_slice_params(AVCodecContext *avctx,
@@ -130,5 +130,5 @@ index 4d0ce87059..b7ddcf13e7 100644
          { "low_delay_b", "Use low delay B-frames with forward-prediction only",
                            0, AV_OPT_TYPE_CONST, { .i64 = 1 }, INT_MIN, INT_MAX, FLAGS, "b_strategy" },
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0051-avframe-zero-the-frame-including-padding-data.patch
+++ b/patches/0051-avframe-zero-the-frame-including-padding-data.patch
@@ -1,4 +1,4 @@
-From 6669ca13d60a6a9c54897e8c3900b2d70be5dade Mon Sep 17 00:00:00 2001
+From 855c8f662558a0eb700e571e30196754b4daa393 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 1 Dec 2020 10:32:58 +0800
 Subject: [PATCH 51/92] avframe: zero the frame, including padding data
@@ -8,7 +8,7 @@ Subject: [PATCH 51/92] avframe: zero the frame, including padding data
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavutil/frame.c b/libavutil/frame.c
-index b0ceaf7145..3fe6fca134 100644
+index 2617cda2b51d..5689544a9698 100644
 --- a/libavutil/frame.c
 +++ b/libavutil/frame.c
 @@ -164,7 +164,7 @@ static int get_video_buffer(AVFrame *frame, int align)
@@ -21,5 +21,5 @@ index b0ceaf7145..3fe6fca134 100644
          ret = AVERROR(ENOMEM);
          goto fail;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0052-libavcodec-qsvenc.c-add-max_frame_size-support-for-h.patch
+++ b/patches/0052-libavcodec-qsvenc.c-add-max_frame_size-support-for-h.patch
@@ -1,4 +1,4 @@
-From ea97b52897fd2fc67049e1c1c8ec505b2e3c7cbc Mon Sep 17 00:00:00 2001
+From 3b69cbcab34861654be6cf631647841ef4335149 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 30 Nov 2020 13:30:49 +0800
 Subject: [PATCH 52/92] libavcodec/qsvenc.c: add max_frame_size support for
@@ -12,7 +12,7 @@ Signed-off-by: Wenbin CHEN <wenbin.chen@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 2fc11ce7a1..29540d5f7d 100644
+index 680da8a36f26..065f69b8e87e 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -707,7 +707,7 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
@@ -25,5 +25,5 @@ index 2fc11ce7a1..29540d5f7d 100644
                  q->extco2.IntRefType = q->int_ref_type;
              if (q->int_ref_cycle_size >= 0)
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0053-libavcodec-qsvenc-add-DisableDeblockingIdc-support-f.patch
+++ b/patches/0053-libavcodec-qsvenc-add-DisableDeblockingIdc-support-f.patch
@@ -1,4 +1,4 @@
-From 26198d632d8f73d349884405651f955f5b253626 Mon Sep 17 00:00:00 2001
+From 37ca5b2212fe11c2cd2aa31495c88b87a36ff26e Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 4 Jan 2021 09:49:22 +0800
 Subject: [PATCH 53/92] libavcodec/qsvenc: add DisableDeblockingIdc support for
@@ -13,7 +13,7 @@ Sigend-off-by: Wenbin Chen <wenbin.chen@intel.com>
  2 files changed, 9 insertions(+)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 29540d5f7d..0884e20bfc 100644
+index 065f69b8e87e..228eb0bd82cc 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -302,6 +302,8 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
@@ -37,7 +37,7 @@ index 29540d5f7d..0884e20bfc 100644
  #if QSV_HAVE_TRELLIS
              if (avctx->trellis >= 0)
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 31516b8e55..c79fdff41f 100644
+index 31516b8e55b4..c79fdff41f3f 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -44,6 +44,7 @@
@@ -65,5 +65,5 @@ index 31516b8e55..c79fdff41f 100644
      int tile_cols;
      int tile_rows;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0054-libavcodec-qsvenc-add-low-latency-P-pyramid-support-.patch
+++ b/patches/0054-libavcodec-qsvenc-add-low-latency-P-pyramid-support-.patch
@@ -1,4 +1,4 @@
-From 46ec967e58a6133afb2dd0d35d2769ba69bf53c1 Mon Sep 17 00:00:00 2001
+From c32478f706e9483283a4b85704b2d7ea1337819c Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 4 Jan 2021 09:52:34 +0800
 Subject: [PATCH 54/92] libavcodec/qsvenc: add low latency P-pyramid support
@@ -17,7 +17,7 @@ Signed-off-by Wenbin Chen <wenbin.chen@intel.com>
  2 files changed, 32 insertions(+)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 0884e20bfc..00e5bd1201 100644
+index 228eb0bd82cc..6633f60154b5 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -271,6 +271,14 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
@@ -65,7 +65,7 @@ index 0884e20bfc..00e5bd1201 100644
          if (avctx->codec_id == AV_CODEC_ID_HEVC)
              q->extco3.GPB              = q->gpb ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index c79fdff41f..8ed20b0934 100644
+index c79fdff41f3f..8ed20b093443 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -95,6 +95,7 @@
@@ -85,5 +85,5 @@ index c79fdff41f..8ed20b0934 100644
  
      int int_ref_type;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0055-lavc-vaapi_hevc-vp9-support-444-8-10bit-enc.patch
+++ b/patches/0055-lavc-vaapi_hevc-vp9-support-444-8-10bit-enc.patch
@@ -1,4 +1,4 @@
-From 009c7d0f5a93419d633842019d4d2bb6329a6059 Mon Sep 17 00:00:00 2001
+From e97a9b6acf928da345a520b4531c7c9f9d3a8b59 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 14 Jan 2021 13:15:32 -0500
 Subject: [PATCH 55/92] lavc/vaapi_hevc/vp9: support 444 8/10bit enc
@@ -22,7 +22,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  2 files changed, 4 insertions(+)
 
 diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index b7ddcf13e7..3ec24defe3 100644
+index b7ddcf13e7dd..3ec24defe36c 100644
 --- a/libavcodec/vaapi_encode_h265.c
 +++ b/libavcodec/vaapi_encode_h265.c
 @@ -1182,6 +1182,8 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
@@ -35,7 +35,7 @@ index b7ddcf13e7..3ec24defe3 100644
      { FF_PROFILE_HEVC_REXT,    12, 3, 1, 0, VAProfileHEVCMain422_12 },
      { FF_PROFILE_HEVC_REXT,    12, 3, 0, 0, VAProfileHEVCMain444_12 },
 diff --git a/libavcodec/vaapi_encode_vp9.c b/libavcodec/vaapi_encode_vp9.c
-index b3f45fb8fe..da706f140f 100644
+index b3f45fb8fe6f..da706f140fcc 100644
 --- a/libavcodec/vaapi_encode_vp9.c
 +++ b/libavcodec/vaapi_encode_vp9.c
 @@ -209,7 +209,9 @@ static av_cold int vaapi_encode_vp9_configure(AVCodecContext *avctx)
@@ -49,5 +49,5 @@ index b3f45fb8fe..da706f140f 100644
  };
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0056-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
+++ b/patches/0056-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
@@ -1,4 +1,4 @@
-From 48ad49faf0f07025fbf9bfd11a0407d9f2044eec Mon Sep 17 00:00:00 2001
+From 524bd7b0c7484996b2276030e704e337171d8bdf Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 18 Jan 2021 16:22:29 +0800
 Subject: [PATCH 56/92] libavcodec/qsvdec.c: extract frame packing arrangement
@@ -15,7 +15,7 @@ Sigend-off-by: Wenbin Chen <wenbin.chen@intel.com>
  2 files changed, 157 insertions(+)
 
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 8090b748b3..9053070482 100644
+index 8090b748b30e..90530704824a 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -52,6 +52,8 @@
@@ -28,7 +28,7 @@ index 8090b748b3..9053070482 100644
      (MFX_VERSION_MAJOR > (MAJOR) ||         \
       MFX_VERSION_MAJOR == (MAJOR) && MFX_VERSION_MINOR >= (MINOR))
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 8bce9f2cf0..1d1a208ef3 100644
+index 8bce9f2cf0f3..1d1a208ef3d9 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -38,12 +38,15 @@
@@ -230,5 +230,5 @@ index 8bce9f2cf0..1d1a208ef3 100644
  
  static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0057-libavcodec-qsvenc-Add-transform-skip-for-hevc_qsv.patch
+++ b/patches/0057-libavcodec-qsvenc-Add-transform-skip-for-hevc_qsv.patch
@@ -1,4 +1,4 @@
-From 48fb7eaeebf23408ef2fa4357d03e785171bb42d Mon Sep 17 00:00:00 2001
+From f24ae308db835eb0ff59cf9b6d63afe21a8945c0 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Thu, 21 Jan 2021 14:14:37 +0800
 Subject: [PATCH 57/92] libavcodec/qsvenc: Add transform skip for hevc_qsv
@@ -16,7 +16,7 @@ Signed-off-by Wenbin Chen <wenbin.chen@intel.com>
  3 files changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 00e5bd1201..f2bf66dee9 100644
+index 6633f60154b5..5efb5c538b5c 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -311,7 +311,9 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
@@ -47,7 +47,7 @@ index 00e5bd1201..f2bf66dee9 100644
  #endif
      }
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 8ed20b0934..789a465bc6 100644
+index 8ed20b093443..789a465bc62c 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -199,6 +199,7 @@ typedef struct QSVEncContext {
@@ -59,7 +59,7 @@ index 8ed20b0934..789a465bc6 100644
      int a53_cc;
  
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index ced9fe026f..13b0347798 100644
+index ced9fe026f4f..13b034779833 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -251,6 +251,9 @@ static const AVOption options[] = {
@@ -73,5 +73,5 @@ index ced9fe026f..13b0347798 100644
      { NULL },
  };
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0058-libavcodec-qsvenc.c-add-ROI-support-to-qsv-encoder.patch
+++ b/patches/0058-libavcodec-qsvenc.c-add-ROI-support-to-qsv-encoder.patch
@@ -1,4 +1,4 @@
-From 778bc8fda3592a2432745ea8aa8149aeb8db8726 Mon Sep 17 00:00:00 2001
+From ab821e2a30d7e068c267f7f954356fb8c47b6d22 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Thu, 14 Jan 2021 15:55:47 +0800
 Subject: [PATCH 58/92] libavcodec/qsvenc.c: add ROI support to qsv encoder
@@ -16,7 +16,7 @@ Sigend-off-by: Wenbin Chen <wenbin.chen@intel.com>
  2 files changed, 77 insertions(+)
 
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 9053070482..870c818c94 100644
+index 90530704824a..870c818c9443 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -51,6 +51,9 @@
@@ -30,7 +30,7 @@ index 9053070482..870c818c94 100644
  #define QSV_PAYLOAD_SIZE 1024
  
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 5efb5c538b..c4e40591e2 100644
+index 5efb5c538b5c..c4e40591e2c2 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -1319,6 +1319,13 @@ static void clear_unused_frames(QSVEncContext *q)
@@ -157,5 +157,5 @@ index 5efb5c538b..c4e40591e2 100644
          cur = q->work_frames;
      }
 -- 
-2.25.1
+2.25.4
 

--- a/patches/0059-libavocdec-qsvenc_hevc-encode-RGB-format-rawvideo.patch
+++ b/patches/0059-libavocdec-qsvenc_hevc-encode-RGB-format-rawvideo.patch
@@ -1,4 +1,4 @@
-From a43cebc7da437b9df5d6b4e265a0d76834470e5c Mon Sep 17 00:00:00 2001
+From 20e65376bece3ea3dfd79a8d1b335154fc080a82 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Thu, 21 Jan 2021 15:46:19 +0800
 Subject: [PATCH 59/92] libavocdec/qsvenc_hevc: encode RGB format rawvideo
@@ -20,7 +20,7 @@ Sigend-of-by: Wenbin Chen <wenbin.chen@intel.com>
  3 files changed, 39 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index bbae639983..9bc01a0869 100644
+index b9deb6b1a629..ce1f4dff7d5f 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -186,6 +186,12 @@ int ff_qsv_print_warning(void *log_ctx, mfxStatus err,
@@ -54,7 +54,7 @@ index bbae639983..9bc01a0869 100644
      case AV_PIX_FMT_YUYV422:
          *fourcc = MFX_FOURCC_YUY2;
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 2af6a3a6ef..401ba0b280 100644
+index c4e40591e2c2..d3d3bc52c06d 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -626,6 +626,13 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
@@ -71,7 +71,7 @@ index 2af6a3a6ef..401ba0b280 100644
      switch (q->param.mfx.RateControlMethod) {
      case MFX_RATECONTROL_CBR:
      case MFX_RATECONTROL_VBR:
-@@ -1450,8 +1457,16 @@ static int submit_frame(QSVEncContext *q, const AVFrame *frame,
+@@ -1452,8 +1459,16 @@ static int submit_frame(QSVEncContext *q, const AVFrame *frame,
              qf->surface.Info.PicStruct |= MFX_PICSTRUCT_FRAME_TRIPLING;
  
          qf->surface.Data.PitchLow  = qf->frame->linesize[0];
@@ -91,7 +91,7 @@ index 2af6a3a6ef..401ba0b280 100644
  
      qf->surface.Data.TimeStamp = av_rescale_q(frame->pts, q->avctx->time_base, (AVRational){1, 90000});
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index 13b0347798..1b2fc0bcc4 100644
+index 13b034779833..1b2fc0bcc430 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -291,6 +291,12 @@ const AVCodec ff_hevc_qsv_encoder = {
@@ -108,5 +108,5 @@ index 13b0347798..1b2fc0bcc4 100644
      .priv_class     = &class,
      .defaults       = qsv_enc_defaults,
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0060-libavcodec-qsvenc-add-horizontal-intra-refresh-and-r.patch
+++ b/patches/0060-libavcodec-qsvenc-add-horizontal-intra-refresh-and-r.patch
@@ -1,4 +1,4 @@
-From 7428af8f8fd261e676b799359b9a9db4c6cabdc0 Mon Sep 17 00:00:00 2001
+From 90e6e29876a742cd1560b323ae33b7dacace6457 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Thu, 21 Jan 2021 14:38:46 +0800
 Subject: [PATCH 60/92] libavcodec/qsvenc: add horizontal intra refresh and
@@ -16,7 +16,7 @@ Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
  3 files changed, 16 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 401ba0b280..4569286492 100644
+index d3d3bc52c06d..2de9f602a507 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -220,8 +220,10 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
@@ -47,7 +47,7 @@ index 401ba0b280..4569286492 100644
  #if QSV_VERSION_ATLEAST(1, 26)
              q->extco3.TransformSkip  = q->transform_skip ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 789a465bc6..f3f21959e7 100644
+index 789a465bc62c..f3f21959e783 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -194,6 +194,7 @@ typedef struct QSVEncContext {
@@ -59,7 +59,7 @@ index 789a465bc6..f3f21959e7 100644
  
      int repeat_pps;
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 80fe3cc280..3a07b412d6 100644
+index 80fe3cc280b9..3a07b412d668 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -129,10 +129,13 @@ static const AVOption options[] = {
@@ -78,5 +78,5 @@ index 80fe3cc280..3a07b412d6 100644
      { "unknown" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_UNKNOWN      }, INT_MIN, INT_MAX,     VE, "profile" },
      { "baseline", NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_AVC_BASELINE }, INT_MIN, INT_MAX,     VE, "profile" },
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0061-libavcodec-qsvdec-move-unref-before-get_format.patch
+++ b/patches/0061-libavcodec-qsvdec-move-unref-before-get_format.patch
@@ -1,4 +1,4 @@
-From 6dad9cfd0c31769543f01643153aabd906eeccdb Mon Sep 17 00:00:00 2001
+From 30e395d57c9a12a1d12c667539a6c8478a6efdfe Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 18 Jan 2021 17:08:39 +0800
 Subject: [PATCH 61/92] libavcodec/qsvdec: move unref before get_format
@@ -17,7 +17,7 @@ Signed-off-by Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 2 insertions(+)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 1d1a208ef3..4c74de68b1 100644
+index 1d1a208ef3d9..4c74de68b128 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -236,6 +236,8 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
@@ -30,5 +30,5 @@ index 1d1a208ef3..4c74de68b1 100644
      if (ret < 0) {
          q->orig_pix_fmt = avctx->pix_fmt = AV_PIX_FMT_NONE;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0062-libavcodec-qsvdec.c-using-queue-count-to-unref-frame.patch
+++ b/patches/0062-libavcodec-qsvdec.c-using-queue-count-to-unref-frame.patch
@@ -1,4 +1,4 @@
-From 185d6a1801845b4b9a3443b968f5ab7681c530e7 Mon Sep 17 00:00:00 2001
+From 9a5a8d197c445da736a2330e365cd3594a5c8658 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Fri, 12 Mar 2021 10:33:37 +0800
 Subject: [PATCH 62/92] libavcodec/qsvdec.c: using queue count to unref frame
@@ -14,7 +14,7 @@ Signed-off-by Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 4c74de68b1..3fb3e52013 100644
+index 4c74de68b128..3fb3e5201357 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -721,7 +721,7 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
@@ -36,5 +36,5 @@ index 4c74de68b1..3fb3e52013 100644
          if (avctx->pix_fmt != AV_PIX_FMT_QSV) {
              do {
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0063-hwdevice-workaround-disalbe-qsv-vaapi-qsv-derivation.patch
+++ b/patches/0063-hwdevice-workaround-disalbe-qsv-vaapi-qsv-derivation.patch
@@ -1,4 +1,4 @@
-From e37361b4e7f30c203e5923412aa2701bcdba8075 Mon Sep 17 00:00:00 2001
+From 3c43cbb41d01151fccb91b1705f09feea753b797 Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Mon, 15 Mar 2021 14:29:41 +0800
 Subject: [PATCH 63/92] hwdevice: workaround disalbe qsv->vaapi->qsv derivation
@@ -11,7 +11,7 @@ see https://patchwork.ffmpeg.org/project/ffmpeg/patch/20210222084504.339978-1-gu
  1 file changed, 2 insertions(+)
 
 diff --git a/libavutil/tests/hwdevice.c b/libavutil/tests/hwdevice.c
-index 7eb355c988..0c168377a7 100644
+index 7eb355c98826..0c168377a72c 100644
 --- a/libavutil/tests/hwdevice.c
 +++ b/libavutil/tests/hwdevice.c
 @@ -73,10 +73,12 @@ static int test_derivation(AVBufferRef *src_ref, const char *src_name)
@@ -28,5 +28,5 @@ index 7eb355c988..0c168377a7 100644
  
          fprintf(stderr, "Successfully tested derivation %s -> %s.\n",
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0064-avutils-hwcontext_qsv-set-the-source-device-in-qsv_d.patch
+++ b/patches/0064-avutils-hwcontext_qsv-set-the-source-device-in-qsv_d.patch
@@ -1,4 +1,4 @@
-From 216ab7530d1064c1d217c0c21ac1d03acc0a170a Mon Sep 17 00:00:00 2001
+From 10fe1df1ae63382c8d03f19b66ee5f673d6a8cbd Mon Sep 17 00:00:00 2001
 From: Xu Guangxin <guangxin.xu@intel.com>
 Date: Tue, 23 Feb 2021 15:22:34 +0800
 Subject: [PATCH 64/92] avutils/hwcontext_qsv: set the source device in
@@ -14,10 +14,10 @@ ffmpeg -init_hw_device vaapi=intel:/dev/dri/renderD128 -init_hw_device opencl=oc
  1 file changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 8acc9d62ff..2498491b58 100644
+index 16966016710d..444cdf98f24d 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -1553,7 +1553,13 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1560,7 +1560,13 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
  
      impl = choose_implementation(device, child_device_type);
  
@@ -33,5 +33,5 @@ index 8acc9d62ff..2498491b58 100644
  
  const HWContextType ff_hwcontext_type_qsv = {
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0065-libavcodec-qsvdec-use-the-param-from-decodeHeader-to.patch
+++ b/patches/0065-libavcodec-qsvdec-use-the-param-from-decodeHeader-to.patch
@@ -1,4 +1,4 @@
-From f801a25806f79f9e25ff93755205d6c8898178f1 Mon Sep 17 00:00:00 2001
+From d394535edbaba0d5fff1ef164dcdec400e7f08c8 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Fri, 12 Mar 2021 13:56:52 +0800
 Subject: [PATCH 65/92] libavcodec/qsvdec: use the param from decodeHeader to
@@ -16,7 +16,7 @@ Signed-off-by Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 3fb3e52013..ab0663cc2e 100644
+index 3fb3e5201357..ab0663cc2e90 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -419,13 +419,13 @@ static int alloc_frame(AVCodecContext *avctx, QSVContext *q, QSVFrame *frame)
@@ -36,5 +36,5 @@ index 3fb3e52013..ab0663cc2e 100644
          ret = ff_qsv_find_surface_idx(&q->frames_ctx, frame);
          if (ret < 0)
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0066-libavcodec-qsvenc-add-more-ChromaFormat-support-for-.patch
+++ b/patches/0066-libavcodec-qsvenc-add-more-ChromaFormat-support-for-.patch
@@ -1,4 +1,4 @@
-From 122736936dec65c92b2e52c3931ee2656a93931e Mon Sep 17 00:00:00 2001
+From 7ea7549c2308c08123abbb631d59f49ff52cf7c9 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Wed, 17 Mar 2021 13:44:01 +0800
 Subject: [PATCH 66/92] libavcodec/qsvenc: add more ChromaFormat support for
@@ -14,7 +14,7 @@ Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 4569286492..a2c6e4c665 100644
+index 2de9f602a507..3d7e967c3a0e 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -468,7 +468,8 @@ static int init_video_param_jpeg(AVCodecContext *avctx, QSVEncContext *q)
@@ -28,5 +28,5 @@ index 4569286492..a2c6e4c665 100644
      q->param.mfx.FrameInfo.BitDepthChroma = desc->comp[0].depth;
      q->param.mfx.FrameInfo.Shift          = desc->comp[0].shift > 0;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0067-libavfilter-qsvvpp-change-the-output-frame-s-width-a.patch
+++ b/patches/0067-libavfilter-qsvvpp-change-the-output-frame-s-width-a.patch
@@ -1,4 +1,4 @@
-From 3d7a3306ea3f90f0d4150314df96b508157e7065 Mon Sep 17 00:00:00 2001
+From a5bbc68ac07b1f321a9ebf57290e9cb53bd59fd6 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Tue, 23 Mar 2021 16:24:03 +0800
 Subject: [PATCH 67/92] libavfilter/qsvvpp: change the output frame's width and
@@ -19,7 +19,7 @@ Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 2 insertions(+), 3 deletions(-)
 
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 135d4c4e36..56b293c3d8 100644
+index d1218355c71a..a44022c90c9f 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -460,15 +460,14 @@ static QSVFrame *query_frame(QSVVPPContext *s, AVFilterLink *outlink)
@@ -41,5 +41,5 @@ index 135d4c4e36..56b293c3d8 100644
  
      return out_frame;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0068-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
+++ b/patches/0068-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
@@ -1,4 +1,4 @@
-From 9447343a77529cfb1467aa15d466468a64d4fc37 Mon Sep 17 00:00:00 2001
+From 1b094c0f8ee8a09ec614904800102d8bf1ea38c6 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 3 Feb 2021 09:08:27 +0800
 Subject: [PATCH 68/92] configure: ensure --enable-libmfx uses libmfx 1.x
@@ -20,10 +20,10 @@ used obsolete features.
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index dc71dbc288..e2f0a18abe 100755
+index 9a4841b8b1db..84a5e2321aa1 100755
 --- a/configure
 +++ b/configure
-@@ -6435,8 +6435,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6436,8 +6436,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
@@ -38,5 +38,5 @@ index dc71dbc288..e2f0a18abe 100755
     check_cc MFX_CODEC_VP9 "mfx/mfxvp9.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
  fi
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0069-configure-fix-the-check-for-MFX_CODEC_VP9.patch
+++ b/patches/0069-configure-fix-the-check-for-MFX_CODEC_VP9.patch
@@ -1,4 +1,4 @@
-From 19428f7f0c9f9e6e1e4f14792620be4cc22c7dbe Mon Sep 17 00:00:00 2001
+From 5d2180700b3405aef4d0b1d84dcc8279df44c56e Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Fri, 19 Feb 2021 08:51:35 +0800
 Subject: [PATCH 69/92] configure: fix the check for MFX_CODEC_VP9
@@ -18,10 +18,10 @@ from oneVPL [1]
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index e2f0a18abe..ccf4bb660c 100755
+index 84a5e2321aa1..3bc07801804b 100755
 --- a/configure
 +++ b/configure
-@@ -6441,7 +6441,7 @@ enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfx
+@@ -6442,7 +6442,7 @@ enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfx
                                      "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
  
  if enabled libmfx; then
@@ -31,5 +31,5 @@ index e2f0a18abe..ccf4bb660c 100755
  
  enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0070-qsv-remove-mfx-prefix-from-mfx-headers.patch
+++ b/patches/0070-qsv-remove-mfx-prefix-from-mfx-headers.patch
@@ -1,4 +1,4 @@
-From 605770c1b00bb07850d239f4f31568e90453e3ef Mon Sep 17 00:00:00 2001
+From a81c2898a9686efdbd7ba05f6a01ff6d2d93dd37 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 8 Sep 2020 11:17:27 +0800
 Subject: [PATCH 70/92] qsv: remove mfx/ prefix from mfx headers
@@ -46,10 +46,10 @@ installed under vpl directory)
  18 files changed, 29 insertions(+), 24 deletions(-)
 
 diff --git a/configure b/configure
-index ccf4bb660c..177980ad5b 100755
+index 3bc07801804b..07ec0311d896 100755
 --- a/configure
 +++ b/configure
-@@ -6435,13 +6435,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6436,13 +6436,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
@@ -73,7 +73,7 @@ index ccf4bb660c..177980ad5b 100755
  
  enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 9bc01a0869..8a23fdf96c 100644
+index ce1f4dff7d5f..940d2c46e655 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -18,9 +18,9 @@
@@ -99,7 +99,7 @@ index 9bc01a0869..8a23fdf96c 100644
  
  int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
 diff --git a/libavcodec/qsv.h b/libavcodec/qsv.h
-index b77158ec26..04ae0d6f34 100644
+index b77158ec2629..04ae0d6f3426 100644
 --- a/libavcodec/qsv.h
 +++ b/libavcodec/qsv.h
 @@ -21,7 +21,7 @@
@@ -112,7 +112,7 @@ index b77158ec26..04ae0d6f34 100644
  #include "libavutil/buffer.h"
  
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 870c818c94..d2007cda7d 100644
+index 870c818c9443..d2007cda7d9c 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -39,7 +39,7 @@
@@ -125,7 +125,7 @@ index 870c818c94..d2007cda7d 100644
  #include "libavutil/frame.h"
  
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index ab0663cc2e..9442ed0e5c 100644
+index ab0663cc2e90..9442ed0e5cc3 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -25,7 +25,7 @@
@@ -138,7 +138,7 @@ index ab0663cc2e..9442ed0e5c 100644
  #include "libavutil/common.h"
  #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index a2c6e4c665..880f5ca39d 100644
+index 3d7e967c3a0e..6727d1955414 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -23,7 +23,7 @@
@@ -151,7 +151,7 @@ index a2c6e4c665..880f5ca39d 100644
  #include "libavutil/common.h"
  #include "libavutil/hwcontext.h"
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index f3f21959e7..8cff75c684 100644
+index f3f21959e783..8cff75c68403 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -26,7 +26,7 @@
@@ -164,7 +164,7 @@ index f3f21959e7..8cff75c684 100644
  #include "libavutil/avutil.h"
  #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 3a07b412d6..68555a0735 100644
+index 3a07b412d668..68555a073591 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -24,7 +24,7 @@
@@ -177,7 +177,7 @@ index 3a07b412d6..68555a0735 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index 1b2fc0bcc4..8b01679eab 100644
+index 1b2fc0bcc430..8b01679eabde 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -22,7 +22,7 @@
@@ -190,7 +190,7 @@ index 1b2fc0bcc4..8b01679eab 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
-index dd082692be..ad8f09befe 100644
+index dd082692be55..ad8f09befe49 100644
 --- a/libavcodec/qsvenc_jpeg.c
 +++ b/libavcodec/qsvenc_jpeg.c
 @@ -22,7 +22,7 @@
@@ -203,7 +203,7 @@ index dd082692be..ad8f09befe 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
-index 525df99e50..610bbf79c1 100644
+index 525df99e5035..610bbf79c197 100644
 --- a/libavcodec/qsvenc_mpeg2.c
 +++ b/libavcodec/qsvenc_mpeg2.c
 @@ -22,7 +22,7 @@
@@ -216,7 +216,7 @@ index 525df99e50..610bbf79c1 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
-index 9329990d11..0a382eb76d 100644
+index 9329990d11d6..0a382eb76d9d 100644
 --- a/libavcodec/qsvenc_vp9.c
 +++ b/libavcodec/qsvenc_vp9.c
 @@ -22,7 +22,7 @@
@@ -229,7 +229,7 @@ index 9329990d11..0a382eb76d 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index e0f4c8f5bb..8c0cf3ed95 100644
+index e0f4c8f5bb4a..8c0cf3ed9525 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -24,7 +24,7 @@
@@ -242,7 +242,7 @@ index e0f4c8f5bb..8c0cf3ed95 100644
  #include "avfilter.h"
  #include "libavutil/fifo.h"
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index 18b9a17760..d9332fb90e 100644
+index fb54d179ed9c..b8ff3e8339df 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -21,7 +21,7 @@
@@ -255,7 +255,7 @@ index 18b9a17760..d9332fb90e 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 2ab04457a9..fa8ba1f670 100644
+index 371f62945708..2ba7d086b79b 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -21,7 +21,7 @@
@@ -268,7 +268,7 @@ index 2ab04457a9..fa8ba1f670 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavutil/hwcontext_opencl.c b/libavutil/hwcontext_opencl.c
-index 41fac43229..fa72d9920b 100644
+index 26a3a2459367..194165fba2c3 100644
 --- a/libavutil/hwcontext_opencl.c
 +++ b/libavutil/hwcontext_opencl.c
 @@ -47,7 +47,7 @@
@@ -281,7 +281,7 @@ index 41fac43229..fa72d9920b 100644
  #include <va/va.h>
  #include <CL/cl_va_api_media_sharing_intel.h>
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 2498491b58..960a79fe30 100644
+index 444cdf98f24d..e543d99cd62a 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -19,7 +19,7 @@
@@ -294,7 +294,7 @@ index 2498491b58..960a79fe30 100644
  #include "config.h"
  
 diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
-index b98d611cfc..42e34d0dda 100644
+index b98d611cfc40..42e34d0dda96 100644
 --- a/libavutil/hwcontext_qsv.h
 +++ b/libavutil/hwcontext_qsv.h
 @@ -19,7 +19,7 @@
@@ -307,5 +307,5 @@ index b98d611cfc..42e34d0dda 100644
  /**
   * @file
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0071-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
+++ b/patches/0071-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
@@ -1,4 +1,4 @@
-From 0062a6a176ef868222ebd1f350a70d7c1ab5e2b9 Mon Sep 17 00:00:00 2001
+From 26d33cb4d96037d26e1d42cf1a596c5ca43a8220 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 18 Aug 2020 15:20:38 +0800
 Subject: [PATCH 71/92] qsv: load user plugin for MFX_VERSION < 2.0
@@ -14,7 +14,7 @@ preparation for oneVPL Support
  2 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 8a23fdf96c..ca6f6dbf56 100644
+index 940d2c46e655..f1a77b5099ed 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -19,7 +19,6 @@
@@ -59,7 +59,7 @@ index 8a23fdf96c..ca6f6dbf56 100644
      return 0;
  
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index d2007cda7d..f34d8b789a 100644
+index d2007cda7d9c..f34d8b789afa 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -65,6 +65,8 @@
@@ -72,5 +72,5 @@ index d2007cda7d..f34d8b789a 100644
      AVBufferRef *hw_frames_ref;
      mfxHDLPair *handle_pair;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0072-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
+++ b/patches/0072-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
@@ -1,4 +1,4 @@
-From 9b7c91f68b811c5813bee3092a3206777481d135 Mon Sep 17 00:00:00 2001
+From 21415a9e1ab3e1d39da77a8adc29f3258d929586 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 18 Aug 2020 15:30:32 +0800
 Subject: [PATCH 72/92] qsv: build audio related code when MFX_VERSION < 2.0
@@ -15,7 +15,7 @@ preparation for oneVPL support
  3 files changed, 13 insertions(+)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index ca6f6dbf56..6a6658fe06 100644
+index f1a77b5099ed..f413fdd03fee 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -37,6 +37,7 @@
@@ -48,7 +48,7 @@ index ca6f6dbf56..6a6658fe06 100644
  
  /**
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 56b293c3d8..dbee718879 100644
+index a44022c90c9f..7cbd104f40f6 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -38,6 +38,8 @@
@@ -82,7 +82,7 @@ index 56b293c3d8..dbee718879 100644
  
  static int qsv_map_error(mfxStatus mfx_err, const char **desc)
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index 8c0cf3ed95..46e90c1d2c 100644
+index 8c0cf3ed9525..46e90c1d2c89 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -40,6 +40,8 @@
@@ -95,5 +95,5 @@ index 8c0cf3ed95..46e90c1d2c 100644
      AVFrame          *frame;
      mfxFrameSurface1 surface;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0073-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
+++ b/patches/0073-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
@@ -1,4 +1,4 @@
-From e66d8ebef1a43d0fd8ed804931e0d0a62952abc6 Mon Sep 17 00:00:00 2001
+From d86cc52557e405d7ffeffffc9dde9e11f1882516 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 12:41:16 +0800
 Subject: [PATCH 73/92] qsvenc: support multi-frame encode when MFX_VERSION <
@@ -14,7 +14,7 @@ in preparation for oneVPL support
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 8cff75c684..ebc47386bd 100644
+index 8cff75c68403..ebc47386bd22 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -65,7 +65,7 @@
@@ -27,5 +27,5 @@ index 8cff75c684..ebc47386bd 100644
  
  #if !QSV_HAVE_LA_DS
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0074-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
+++ b/patches/0074-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
@@ -1,4 +1,4 @@
-From e67a5d49e21a800e183266f6aeb8f9a25eee3b49 Mon Sep 17 00:00:00 2001
+From fd6f69f875dc4c245b70f684d8521377bc597815 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 12:49:14 +0800
 Subject: [PATCH 74/92] qsvenc: support MFX_RATECONTROL_LA_EXT when MFX_VERSION
@@ -14,7 +14,7 @@ This is in preparation for oneVPL support
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 880f5ca39d..da95c9df01 100644
+index 6727d1955414..e9270a561198 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -103,7 +103,7 @@ static const struct {
@@ -27,5 +27,5 @@ index 880f5ca39d..da95c9df01 100644
  #endif
  #if QSV_HAVE_LA_HRD
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0075-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
+++ b/patches/0075-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
@@ -1,7 +1,7 @@
-From 6af5c293439319d6a555c0967b5138dce0fff381 Mon Sep 17 00:00:00 2001
+From 997368bd61b536cb9abf42e944a3a0e46bb43263 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 09:43:12 +0800
-Subject: [PATCH] qsv: support OPAQUE memory when MFX_VERSION < 2.0
+Subject: [PATCH 75/92] qsv: support OPAQUE memory when MFX_VERSION < 2.0
 
 OPAQUE memory isn't supported for MFX_VERSION >= 2.0[1][2]. This is in
 preparation for oneVPL support
@@ -99,7 +99,7 @@ index 9442ed0e5cc3..f18135f41785 100644
      }
  
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 5947036de078..0a93fd900853 100644
+index e9270a561198..d3d1ffc3623e 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -1095,6 +1095,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
@@ -165,7 +165,7 @@ index 5947036de078..0a93fd900853 100644
      }
  
      ret = MFXVideoENCODE_Init(q->session, &q->param);
-@@ -1813,8 +1832,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1784,8 +1803,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
      av_fifo_free(q->async_fifo);
      q->async_fifo = NULL;
  
@@ -329,7 +329,7 @@ index 46e90c1d2c89..67c351f2977b 100644
      int got_frame;
      int async_depth;
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index ab849558efbe..fe6cb69afe11 100644
+index b8ff3e8339df..50f9156d143d 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -62,7 +62,9 @@ typedef struct QSVDeintContext {
@@ -342,7 +342,7 @@ index ab849558efbe..fe6cb69afe11 100644
      mfxExtVPPDeinterlacing   deint_conf;
      mfxExtBuffer            *ext_buffers[2];
      int                      num_ext_buffers;
-@@ -163,9 +165,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -154,9 +156,7 @@ static int init_out_session(AVFilterContext *ctx)
      AVHWFramesContext    *hw_frames_ctx = (AVHWFramesContext*)s->hw_frames_ctx->data;
      AVQSVFramesContext *hw_frames_hwctx = hw_frames_ctx->hwctx;
      AVQSVDeviceContext    *device_hwctx = hw_frames_ctx->device_ctx->hwctx;
@@ -353,7 +353,7 @@ index ab849558efbe..fe6cb69afe11 100644
      mfxHDL handle = NULL;
      mfxHandleType handle_type;
      mfxVersion ver;
-@@ -174,6 +174,9 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -165,6 +165,9 @@ static int init_out_session(AVFilterContext *ctx)
      mfxStatus err;
      int i;
  
@@ -363,7 +363,7 @@ index ab849558efbe..fe6cb69afe11 100644
      /* extract the properties of the "master" session given to us */
      err = MFXQueryIMPL(device_hwctx->session, &impl);
      if (err == MFX_ERR_NONE)
-@@ -232,28 +235,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -223,28 +226,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->deint_conf;
  
@@ -393,7 +393,7 @@ index ab849558efbe..fe6cb69afe11 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -277,6 +259,31 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -268,6 +250,31 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -426,7 +426,7 @@ index ab849558efbe..fe6cb69afe11 100644
      par.ExtParam    = s->ext_buffers;
      par.NumExtParam = s->num_ext_buffers;
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 19c9bb64634a..6cc6d192ff16 100644
+index 2ba7d086b79b..30434033d105 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -90,7 +90,9 @@ typedef struct QSVScaleContext {
@@ -439,7 +439,7 @@ index 19c9bb64634a..6cc6d192ff16 100644
  
  #if QSV_HAVE_SCALING_CONFIG
      mfxExtVPPScaling         scale_conf;
-@@ -280,7 +282,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -271,7 +273,7 @@ static int init_out_session(AVFilterContext *ctx)
      AVQSVFramesContext *out_frames_hwctx = out_frames_ctx->hwctx;
      AVQSVDeviceContext     *device_hwctx = in_frames_ctx->device_ctx->hwctx;
  
@@ -448,7 +448,7 @@ index 19c9bb64634a..6cc6d192ff16 100644
  
      mfxHDL handle = NULL;
      mfxHandleType handle_type;
-@@ -290,6 +292,9 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -281,6 +283,9 @@ static int init_out_session(AVFilterContext *ctx)
      mfxStatus err;
      int i;
  
@@ -458,7 +458,7 @@ index 19c9bb64634a..6cc6d192ff16 100644
      s->num_ext_buf = 0;
  
      /* extract the properties of the "master" session given to us */
-@@ -342,38 +347,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -333,38 +338,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      memset(&par, 0, sizeof(par));
  
@@ -498,7 +498,7 @@ index 19c9bb64634a..6cc6d192ff16 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -405,6 +379,40 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -396,6 +370,40 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -540,7 +540,7 @@ index 19c9bb64634a..6cc6d192ff16 100644
  #if QSV_HAVE_SCALING_CONFIG
      memset(&s->scale_conf, 0, sizeof(mfxExtVPPScaling));
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index e71fd16ee9d4..23afab99eaff 100644
+index e543d99cd62a..d31c2c7fa69e 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -53,6 +53,8 @@

--- a/patches/0076-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
+++ b/patches/0076-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
@@ -1,4 +1,4 @@
-From de2f6d3291b7b9b094d8a89b8c1d97e9ec00c85b Mon Sep 17 00:00:00 2001
+From 2d643839acb37b0f1f156dbb541951d531517a46 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Mon, 4 Jan 2021 10:46:14 +0800
 Subject: [PATCH 76/92] qsv: use a new method to create mfx session when using
@@ -36,7 +36,7 @@ Signed-off-by: galinart <artem.galin@intel.com>
  15 files changed, 591 insertions(+), 89 deletions(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 48e54df338..f37fe6a64a 100644
+index 48e54df338f2..f37fe6a64a5c 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -436,6 +436,164 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
@@ -270,7 +270,7 @@ index 48e54df338..f37fe6a64a 100644
  #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
      av_buffer_unref(&qs->va_device_ref);
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 286faf7ee8..ca27023c99 100644
+index 286faf7ee8de..ca27023c99b5 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -92,6 +92,7 @@ typedef struct QSVFrame {
@@ -282,7 +282,7 @@ index 286faf7ee8..ca27023c99 100644
      AVBufferRef *va_device_ref;
      AVHWDeviceContext *va_device_ctx;
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index f18135f417..fddb9f7673 100644
+index f18135f41785..fddb9f767334 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -169,7 +169,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
@@ -306,7 +306,7 @@ index f18135f417..fddb9f7673 100644
  
          ret = ff_qsv_init_session_device(avctx, &q->internal_qs.session,
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index c5b1fa5e12..6d8b7b9462 100644
+index c5b1fa5e12ab..6d8b7b946249 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -28,6 +28,9 @@
@@ -320,7 +320,7 @@ index c5b1fa5e12..6d8b7b9462 100644
  #include "libavutil/fifo.h"
  
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 68555a0735..06abc5fc65 100644
+index 68555a073591..06abc5fc657a 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -32,7 +32,6 @@
@@ -332,7 +332,7 @@ index 68555a0735..06abc5fc65 100644
  #include "atsc_a53.h"
  
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index 8b01679eab..83993f733f 100644
+index 8b01679eabde..83993f733fcc 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -35,7 +35,6 @@
@@ -344,7 +344,7 @@ index 8b01679eab..83993f733f 100644
  
  enum LoadPlugin {
 diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
-index ad8f09befe..f473b1ddbc 100644
+index ad8f09befe49..f473b1ddbc7a 100644
 --- a/libavcodec/qsvenc_jpeg.c
 +++ b/libavcodec/qsvenc_jpeg.c
 @@ -30,7 +30,6 @@
@@ -356,7 +356,7 @@ index ad8f09befe..f473b1ddbc 100644
  
  typedef struct QSVMJPEGEncContext {
 diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
-index 610bbf79c1..0e2a51811c 100644
+index 610bbf79c197..0e2a51811c0a 100644
 --- a/libavcodec/qsvenc_mpeg2.c
 +++ b/libavcodec/qsvenc_mpeg2.c
 @@ -30,7 +30,6 @@
@@ -368,7 +368,7 @@ index 610bbf79c1..0e2a51811c 100644
  
  typedef struct QSVMpeg2EncContext {
 diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
-index 0a382eb76d..9d88b03bbf 100644
+index 0a382eb76d9d..9d88b03bbfa9 100644
 --- a/libavcodec/qsvenc_vp9.c
 +++ b/libavcodec/qsvenc_vp9.c
 @@ -30,7 +30,6 @@
@@ -380,7 +380,7 @@ index 0a382eb76d..9d88b03bbf 100644
  
  typedef struct QSVVP9EncContext {
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 9b1af90bb0..ca4a2cf6b2 100644
+index 9b1af90bb094..ca4a2cf6b226 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -23,8 +23,6 @@
@@ -509,7 +509,7 @@ index 9b1af90bb0..ca4a2cf6b2 100644
 +
 +#endif
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index 67c351f297..d1c12be25b 100644
+index 67c351f2977b..d1c12be25b18 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -28,6 +28,8 @@
@@ -530,10 +530,10 @@ index 67c351f297..d1c12be25b 100644
 +
  #endif /* AVFILTER_QSVVPP_H */
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index fe6cb69afe..205b164bf6 100644
+index 50f9156d143d..4986873cbb04 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
-@@ -172,7 +172,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -163,7 +163,7 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -542,7 +542,7 @@ index fe6cb69afe..205b164bf6 100644
  
  #if QSV_HAVE_OPAQUE
      opaque = !!(hw_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
-@@ -207,13 +207,11 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -198,13 +198,11 @@ static int init_out_session(AVFilterContext *ctx)
  
      /* create a "slave" session with those same properties, to be used for
       * actual deinterlacing */
@@ -562,10 +562,10 @@ index fe6cb69afe..205b164bf6 100644
      if (handle) {
          err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 6cc6d192ff..76ed178831 100644
+index 30434033d105..82a51ee83786 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
-@@ -290,7 +290,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -281,7 +281,7 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -574,7 +574,7 @@ index 6cc6d192ff..76ed178831 100644
  
  #if QSV_HAVE_OPAQUE
      opaque = !!(in_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
-@@ -327,11 +327,11 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -318,11 +318,11 @@ static int init_out_session(AVFilterContext *ctx)
  
      /* create a "slave" session with those same properties, to be used for
       * actual scaling */
@@ -592,7 +592,7 @@ index 6cc6d192ff..76ed178831 100644
      if (handle) {
          err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 23afab99ea..5333f73738 100644
+index d31c2c7fa69e..e4f32a7e8852 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
 @@ -72,8 +72,10 @@ typedef struct QSVDeviceContext {
@@ -929,7 +929,7 @@ index 23afab99ea..5333f73738 100644
      s->session_download_init = 0;
      s->session_upload_init   = 0;
  
-@@ -1010,7 +1249,8 @@ static int qsv_transfer_data_from(AVHWFramesContext *ctx, AVFrame *dst,
+@@ -1014,7 +1253,8 @@ static int qsv_transfer_data_from(AVHWFramesContext *ctx, AVFrame *dst,
          if (pthread_mutex_trylock(&s->session_lock) == 0) {
  #endif
              if (!s->session_download_init) {
@@ -939,7 +939,7 @@ index 23afab99ea..5333f73738 100644
                  if (s->session_download)
                      s->session_download_init = 1;
              }
-@@ -1084,7 +1324,8 @@ static int qsv_transfer_data_to(AVHWFramesContext *ctx, AVFrame *dst,
+@@ -1088,7 +1328,8 @@ static int qsv_transfer_data_to(AVHWFramesContext *ctx, AVFrame *dst,
          if (pthread_mutex_trylock(&s->session_lock) == 0) {
  #endif
              if (!s->session_upload_init) {
@@ -949,7 +949,7 @@ index 23afab99ea..5333f73738 100644
                  if (s->session_upload)
                      s->session_upload_init = 1;
              }
-@@ -1353,6 +1594,7 @@ static void qsv_device_free(AVHWDeviceContext *ctx)
+@@ -1357,6 +1598,7 @@ static void qsv_device_free(AVHWDeviceContext *ctx)
      if (hwctx->session)
          MFXClose(hwctx->session);
  
@@ -957,7 +957,7 @@ index 23afab99ea..5333f73738 100644
      av_buffer_unref(&priv->child_device_ctx);
      av_freep(&priv);
  }
-@@ -1442,34 +1684,11 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+@@ -1446,34 +1688,11 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
          goto fail;
      }
  
@@ -995,7 +995,7 @@ index 23afab99ea..5333f73738 100644
  
      err = MFXVideoCORE_SetHandle(hwctx->session, handle_type, handle);
      if (err != MFX_ERR_NONE) {
-@@ -1484,6 +1703,8 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+@@ -1488,6 +1707,8 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
  fail:
      if (hwctx->session)
          MFXClose(hwctx->session);
@@ -1004,7 +1004,7 @@ index 23afab99ea..5333f73738 100644
      return ret;
  }
  
-@@ -1526,6 +1747,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1530,6 +1751,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
          }
      } else if (CONFIG_VAAPI) {
          child_device_type = AV_HWDEVICE_TYPE_VAAPI;
@@ -1021,7 +1021,7 @@ index 23afab99ea..5333f73738 100644
      } else if (CONFIG_DXVA2) {
          av_log(NULL, AV_LOG_WARNING,
                  "WARNING: defaulting child_device_type to AV_HWDEVICE_TYPE_DXVA2 for compatibility "
-@@ -1534,6 +1765,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1538,6 +1769,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
          child_device_type = AV_HWDEVICE_TYPE_DXVA2;
      } else if (CONFIG_D3D11VA) {
          child_device_type = AV_HWDEVICE_TYPE_D3D11VA;
@@ -1029,7 +1029,7 @@ index 23afab99ea..5333f73738 100644
      } else {
          av_log(ctx, AV_LOG_ERROR, "No supported child device type is enabled\n");
          return AVERROR(ENOSYS);
-@@ -1560,6 +1792,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1564,6 +1796,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
  #endif
  #if CONFIG_DXVA2
      case AV_HWDEVICE_TYPE_DXVA2:
@@ -1047,7 +1047,7 @@ index 23afab99ea..5333f73738 100644
  #endif
      default:
 diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
-index 42e34d0dda..65415d3d8c 100644
+index 42e34d0dda96..65415d3d8c4c 100644
 --- a/libavutil/hwcontext_qsv.h
 +++ b/libavutil/hwcontext_qsv.h
 @@ -19,8 +19,23 @@
@@ -1083,5 +1083,5 @@ index 42e34d0dda..65415d3d8c 100644
  } AVQSVDeviceContext;
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0077-configure-add-enable-libvpl-option.patch
+++ b/patches/0077-configure-add-enable-libvpl-option.patch
@@ -1,4 +1,4 @@
-From b8f110fd09369dcd6b7c416e5e28a5cba8c4b7e7 Mon Sep 17 00:00:00 2001
+From 8292b0a9a3be592e6e220ded6fb86c1925d22cc5 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 3 Feb 2021 14:49:46 +0800
 Subject: [PATCH 77/92] configure: add --enable-libvpl option
@@ -13,7 +13,7 @@ enabled.
  1 file changed, 20 insertions(+), 6 deletions(-)
 
 diff --git a/configure b/configure
-index 177980ad5b..16a1111af4 100755
+index 07ec0311d896..2c528eaf355c 100755
 --- a/configure
 +++ b/configure
 @@ -337,6 +337,7 @@ External library support:
@@ -32,7 +32,7 @@ index 177980ad5b..16a1111af4 100755
      mmal
      omx
      opencl
-@@ -6429,22 +6431,34 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
+@@ -6430,22 +6432,34 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
  enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
  enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
  enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
@@ -74,5 +74,5 @@ index 177980ad5b..16a1111af4 100755
     check_cc MFX_CODEC_VP9 "mfxdefs.h mfxstructures.h" "MFX_CODEC_VP9"
  fi
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0078-libavcodec-qsvenc-add-mbbrc-to-hevc_qsv.patch
+++ b/patches/0078-libavcodec-qsvenc-add-mbbrc-to-hevc_qsv.patch
@@ -1,4 +1,4 @@
-From 8b356637b2f1f0ce7693fad0b5c1c7b75dfcd2aa Mon Sep 17 00:00:00 2001
+From 4f51d5812fdef6d2b47d95e3dce0770636f634fe Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Fri, 9 Apr 2021 14:00:40 +0800
 Subject: [PATCH 78/92] libavcodec/qsvenc: add mbbrc to hevc_qsv
@@ -13,7 +13,7 @@ Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
  1 file changed, 3 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 69ee4d6fc2..f1fd748ebb 100644
+index d3d1ffc3623e..17028ca9fef1 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -739,8 +739,6 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
@@ -36,5 +36,5 @@ index 69ee4d6fc2..f1fd748ebb 100644
              q->extco2.Header.BufferSz = sizeof(q->extco2);
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0079-libavcodec-qsvdec-reinit-decoder-according-to-decode.patch
+++ b/patches/0079-libavcodec-qsvdec-reinit-decoder-according-to-decode.patch
@@ -1,4 +1,4 @@
-From c57e128740395d70a59fba3c15b62eb15d39a71b Mon Sep 17 00:00:00 2001
+From 1cce35a4025ad5ddb813351404cab597dab783de Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Tue, 23 Mar 2021 16:16:33 +0800
 Subject: [PATCH 79/92] libavcodec/qsvdec: reinit decoder according to decode()
@@ -16,7 +16,7 @@ Signed-off-by Guangxin Xu <guangxin.xu@intel.com>
  1 file changed, 9 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index fddb9f7673..70ed425ae2 100644
+index fddb9f767334..70ed425ae2c9 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -702,6 +702,13 @@ static int qsv_decode(AVCodecContext *avctx, QSVContext *q,
@@ -46,5 +46,5 @@ index fddb9f7673..70ed425ae2 100644
  
          if (q->buffered_count) {
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0080-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
+++ b/patches/0080-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
@@ -1,4 +1,4 @@
-From b2c6244f84757860a076baa2e594c8ac7616f761 Mon Sep 17 00:00:00 2001
+From aa672a8d407ef92eb4c353473cb0202fe7569f17 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Tue, 16 Mar 2021 14:31:19 +0800
 Subject: [PATCH 80/92] libavcodec/qsvdec: remove redundant decodeHeader()
@@ -17,7 +17,7 @@ Signed-off-by Guangxin Xu <guangxin.xu@intel.com>
  1 file changed, 12 insertions(+), 14 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 70ed425ae2..6a5e4e9abb 100644
+index 70ed425ae2c9..6a5e4e9abb3a 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -76,7 +76,6 @@ typedef struct QSVContext {
@@ -71,5 +71,5 @@ index 70ed425ae2..6a5e4e9abb 100644
          q->orig_pix_fmt = avctx->pix_fmt = pix_fmt = ff_qsv_map_fourcc(param.mfx.FrameInfo.FourCC);
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0081-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
+++ b/patches/0081-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
@@ -1,4 +1,4 @@
-From 11e56c850d1fa649433f10925a1c980243e212c2 Mon Sep 17 00:00:00 2001
+From fb1de9f01f2a79008c4c2788cef2a76b9b1cf1e6 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Tue, 26 Jan 2021 09:55:59 +0800
 Subject: [PATCH 81/92] libavcodec/qsvdec: using suggested num to set
@@ -18,7 +18,7 @@ Signed-off-by Guangxin Xu <guangxin.xu@intel.com>
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 6a5e4e9abb..92a816a344 100644
+index 6a5e4e9abb3a..92a816a34456 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -82,7 +82,7 @@ typedef struct QSVContext {
@@ -69,5 +69,5 @@ index 6a5e4e9abb..92a816a344 100644
          if (ret < 0)
              goto reinit_fail;
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0082-cbs_av1-fix-incorrect-data-type.patch
+++ b/patches/0082-cbs_av1-fix-incorrect-data-type.patch
@@ -1,4 +1,4 @@
-From e5857edaf46181fc30dcde93b37f96b480108f9f Mon Sep 17 00:00:00 2001
+From c14836aa8df6b8f201f309a526efeef85464ab42 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 20 May 2021 16:28:16 -0400
 Subject: [PATCH 82/92] cbs_av1: fix incorrect data type
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/cbs_av1_syntax_template.c b/libavcodec/cbs_av1_syntax_template.c
-index 6fe6e9a4f3..d98d3d42de 100644
+index 6fe6e9a4f356..d98d3d42dea3 100644
 --- a/libavcodec/cbs_av1_syntax_template.c
 +++ b/libavcodec/cbs_av1_syntax_template.c
 @@ -355,7 +355,7 @@ static int FUNC(set_frame_refs)(CodedBitstreamContext *ctx, RWContext *rw,
@@ -26,5 +26,5 @@ index 6fe6e9a4f3..d98d3d42de 100644
      int i, j;
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0083-avcodec-av1-extend-some-definitions-in-spec-section-.patch
+++ b/patches/0083-avcodec-av1-extend-some-definitions-in-spec-section-.patch
@@ -1,4 +1,4 @@
-From f9caa6570f7d59ec23f7ea759ba669d4cd08b792 Mon Sep 17 00:00:00 2001
+From 9e73d45fef7ee6278000d6cc5f2d51f99e2412fb Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 20 May 2021 16:26:39 -0400
 Subject: [PATCH 83/92] avcodec/av1: extend some definitions in spec section 3
@@ -9,7 +9,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 7 insertions(+)
 
 diff --git a/libavcodec/av1.h b/libavcodec/av1.h
-index 0f99ae4829..951a18ecb2 100644
+index 0f99ae4829d9..951a18ecb260 100644
 --- a/libavcodec/av1.h
 +++ b/libavcodec/av1.h
 @@ -114,6 +114,13 @@ enum {
@@ -27,5 +27,5 @@ index 0f99ae4829..951a18ecb2 100644
  
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0084-avcodec-av1dec-support-setup-shear-process.patch
+++ b/patches/0084-avcodec-av1dec-support-setup-shear-process.patch
@@ -1,4 +1,4 @@
-From 03eddbbff291f2e83271ec70123ce629da272da1 Mon Sep 17 00:00:00 2001
+From 5835ccf4087da1b287004818753a2a80680cec7e Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 20 May 2021 16:45:47 -0400
 Subject: [PATCH 84/92] avcodec/av1dec: support setup shear process
@@ -12,7 +12,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  2 files changed, 99 insertions(+)
 
 diff --git a/libavcodec/av1dec.c b/libavcodec/av1dec.c
-index a69808f7b6..db110c50c7 100644
+index a69808f7b676..db110c50c71d 100644
 --- a/libavcodec/av1dec.c
 +++ b/libavcodec/av1dec.c
 @@ -28,6 +28,34 @@
@@ -142,7 +142,7 @@ index a69808f7b6..db110c50c7 100644
             src->gm_type,
             AV1_NUM_REF_FRAMES * sizeof(uint8_t));
 diff --git a/libavcodec/av1dec.h b/libavcodec/av1dec.h
-index 248a68750f..4e140588b9 100644
+index 248a68750f54..4e140588b9e2 100644
 --- a/libavcodec/av1dec.h
 +++ b/libavcodec/av1dec.h
 @@ -42,6 +42,7 @@ typedef struct AV1Frame {
@@ -154,5 +154,5 @@ index 248a68750f..4e140588b9 100644
      int32_t gm_params[AV1_NUM_REF_FRAMES][6];
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0085-avcodec-av1_vaapi-add-gm-params-valid-check.patch
+++ b/patches/0085-avcodec-av1_vaapi-add-gm-params-valid-check.patch
@@ -1,4 +1,4 @@
-From e18737eddb26f66d655430670a6eff293bcbafe3 Mon Sep 17 00:00:00 2001
+From d3bf97f9dc7a50c5761405c270f8df160343882a Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Wed, 9 Jun 2021 14:36:42 +0800
 Subject: [PATCH 85/92] avcodec/av1_vaapi: add gm params valid check
@@ -9,7 +9,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 2 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
-index 16b7e35747..f577447be4 100644
+index 16b7e35747cf..f577447be452 100644
 --- a/libavcodec/vaapi_av1.c
 +++ b/libavcodec/vaapi_av1.c
 @@ -213,7 +213,8 @@ static int vaapi_av1_start_frame(AVCodecContext *avctx,
@@ -23,5 +23,5 @@ index 16b7e35747..f577447be4 100644
              pic_param.wm[i - 1].wmmat[j] = s->cur_frame.gm_params[i][j];
      }
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0086-avcodec-vaapi-increase-av1-decode-pool-size.patch
+++ b/patches/0086-avcodec-vaapi-increase-av1-decode-pool-size.patch
@@ -1,4 +1,4 @@
-From 70bdcae6c663d4f2f3e8e1e7ebdc3e835711b26e Mon Sep 17 00:00:00 2001
+From 76cfa94d7a12caec6e7f5ec60a26a01f45bea8d6 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 3 Jun 2021 13:58:27 -0400
 Subject: [PATCH 86/92] avcodec/vaapi: increase av1 decode pool size
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/vaapi_decode.c b/libavcodec/vaapi_decode.c
-index 8026e0411f..afc1012555 100644
+index 8026e0411f2f..afc10125554b 100644
 --- a/libavcodec/vaapi_decode.c
 +++ b/libavcodec/vaapi_decode.c
 @@ -605,10 +605,10 @@ static int vaapi_decode_make_config(AVCodecContext *avctx,
@@ -29,5 +29,5 @@ index 8026e0411f..afc1012555 100644
              break;
          case AV_CODEC_ID_VP8:
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0087-avcodec-av1dec-add-display-frame-for-film-grain-usag.patch
+++ b/patches/0087-avcodec-av1dec-add-display-frame-for-film-grain-usag.patch
@@ -1,4 +1,4 @@
-From 272347f2bf8170e808a2b711e9680041ad266c72 Mon Sep 17 00:00:00 2001
+From 36f7aad4d949253a88d7b4060d840c1269ed1bd9 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Thu, 3 Jun 2021 13:49:44 -0400
 Subject: [PATCH 87/92] avcodec/av1dec: add display frame for film grain usage
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  2 files changed, 45 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/av1dec.c b/libavcodec/av1dec.c
-index db110c50c7..1fee0225cc 100644
+index db110c50c71d..1fee0225cc01 100644
 --- a/libavcodec/av1dec.c
 +++ b/libavcodec/av1dec.c
 @@ -570,6 +570,8 @@ static int get_pixel_format(AVCodecContext *avctx)
@@ -114,7 +114,7 @@ index db110c50c7..1fee0225cc 100644
      if (s->operating_point_idc &&
          av_log2(s->operating_point_idc >> 8) > s->cur_frame.spatial_id)
 diff --git a/libavcodec/av1dec.h b/libavcodec/av1dec.h
-index 4e140588b9..5af3dfc867 100644
+index 4e140588b9e2..5af3dfc86767 100644
 --- a/libavcodec/av1dec.h
 +++ b/libavcodec/av1dec.h
 @@ -33,6 +33,9 @@
@@ -128,5 +128,5 @@ index 4e140588b9..5af3dfc867 100644
      void *hwaccel_picture_private;
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0088-avcodec-av1_vaapi-set-display-surface-when-apply-fil.patch
+++ b/patches/0088-avcodec-av1_vaapi-set-display-surface-when-apply-fil.patch
@@ -1,4 +1,4 @@
-From bae9bd0ab8db805c559745e5380b60409ea05a13 Mon Sep 17 00:00:00 2001
+From ed482c276a2a4f7ca8ee7fd20e6a951bee9a889b Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Wed, 9 Jun 2021 15:03:03 +0800
 Subject: [PATCH 88/92] avcodec/av1_vaapi: set display surface when apply film
@@ -10,7 +10,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
-index f577447be4..81b13bb1aa 100644
+index f577447be452..81b13bb1aa87 100644
 --- a/libavcodec/vaapi_av1.c
 +++ b/libavcodec/vaapi_av1.c
 @@ -76,7 +76,7 @@ static int vaapi_av1_start_frame(AVCodecContext *avctx,
@@ -23,5 +23,5 @@ index f577447be4..81b13bb1aa 100644
          .frame_height_minus1     = frame_header->frame_height_minus_1,
          .primary_ref_frame       = frame_header->primary_ref_frame,
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0089-avcodec-av1_vaapi-enable-segmentation-features.patch
+++ b/patches/0089-avcodec-av1_vaapi-enable-segmentation-features.patch
@@ -1,4 +1,4 @@
-From d85608ab9da20f74d56eee621d46de994589fc15 Mon Sep 17 00:00:00 2001
+From f2e5f200f7d6c50e788599edd302dff98eb896b6 Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Wed, 9 Jun 2021 15:00:28 +0800
 Subject: [PATCH 89/92] avcodec/av1_vaapi: enable segmentation features
@@ -9,7 +9,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 14 insertions(+)
 
 diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
-index 81b13bb1aa..6aaabed2c1 100644
+index 81b13bb1aa87..6aaabed2c123 100644
 --- a/libavcodec/vaapi_av1.c
 +++ b/libavcodec/vaapi_av1.c
 @@ -63,6 +63,9 @@ static int vaapi_av1_start_frame(AVCodecContext *avctx,
@@ -41,5 +41,5 @@ index 81b13bb1aa..6aaabed2c1 100644
          for (int i = 0; i < film_grain->num_y_points; i++) {
              pic_param.film_grain_info.point_y_value[i] =
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0090-avcodec-av1_vaapi-improve-decode-quality.patch
+++ b/patches/0090-avcodec-av1_vaapi-improve-decode-quality.patch
@@ -1,4 +1,4 @@
-From 0fa093384a58cae3e590a41f05a3f98a01024d9c Mon Sep 17 00:00:00 2001
+From ce3a70e383c365b50cd132ced5b85b920a78605f Mon Sep 17 00:00:00 2001
 From: Fei Wang <fei.w.wang@intel.com>
 Date: Wed, 9 Jun 2021 15:20:08 +0800
 Subject: [PATCH 90/92] avcodec/av1_vaapi: improve decode quality
@@ -13,7 +13,7 @@ Signed-off-by: Fei Wang <fei.w.wang@intel.com>
  1 file changed, 41 insertions(+), 26 deletions(-)
 
 diff --git a/libavcodec/vaapi_av1.c b/libavcodec/vaapi_av1.c
-index 6aaabed2c1..2d0f0a76ad 100644
+index 6aaabed2c123..2d0f0a76ad4b 100644
 --- a/libavcodec/vaapi_av1.c
 +++ b/libavcodec/vaapi_av1.c
 @@ -75,26 +75,35 @@ static int vaapi_av1_start_frame(AVCodecContext *avctx,
@@ -105,5 +105,5 @@ index 6aaabed2c1..2d0f0a76ad 100644
      };
  
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0091-avcodec-vaapi_encode_vp9-fix-4k-encode-fail-issue.patch
+++ b/patches/0091-avcodec-vaapi_encode_vp9-fix-4k-encode-fail-issue.patch
@@ -1,4 +1,4 @@
-From 2ff2b6974d0683853f2b76b7a78fd0097ad3455d Mon Sep 17 00:00:00 2001
+From 26b76b5b9d948c11cbe1b0f4855ddf9176a25436 Mon Sep 17 00:00:00 2001
 From: Zhang yuankun <yuankunx.zhang@intel.com>
 Date: Mon, 12 Apr 2021 09:47:24 +0800
 Subject: [PATCH 91/92] avcodec/vaapi_encode_vp9: fix > 4k encode fail issue
@@ -15,7 +15,7 @@ Signed-off-by: Zhang yuankun <yuankunx.zhang@intel.com>
  1 file changed, 8 insertions(+)
 
 diff --git a/libavcodec/vaapi_encode_vp9.c b/libavcodec/vaapi_encode_vp9.c
-index da706f140f..d705b500eb 100644
+index da706f140fcc..d705b500eb3c 100644
 --- a/libavcodec/vaapi_encode_vp9.c
 +++ b/libavcodec/vaapi_encode_vp9.c
 @@ -31,6 +31,7 @@
@@ -45,5 +45,5 @@ index da706f140f..d705b500eb 100644
      case PICTURE_TYPE_IDR:
          av_assert0(pic->nb_refs == 0);
 -- 
-2.17.1
+2.25.4
 

--- a/patches/0092-avcodec-dxva2_av1-fix-global-motion-params.patch
+++ b/patches/0092-avcodec-dxva2_av1-fix-global-motion-params.patch
@@ -1,4 +1,4 @@
-From b1484edf0aa18b8554ffd6e62c630cde8e4a66f3 Mon Sep 17 00:00:00 2001
+From 39ba15ec7c172ed354056cb99d5983cff7fe6f4d Mon Sep 17 00:00:00 2001
 From: Tong Wu <tong1.wu@intel.com>
 Date: Tue, 24 Aug 2021 09:30:33 +0800
 Subject: [PATCH 92/92] avcodec/dxva2_av1: fix global motion params
@@ -14,7 +14,7 @@ Signed-off-by: Tong Wu <tong1.wu@intel.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/dxva2_av1.c b/libavcodec/dxva2_av1.c
-index aa14e473df..08fee6f7d5 100644
+index c30b57799c2c..8a912bf6c192 100644
 --- a/libavcodec/dxva2_av1.c
 +++ b/libavcodec/dxva2_av1.c
 @@ -139,7 +139,7 @@ static int fill_picture_parameters(const AVCodecContext *avctx, AVDXVAContext *c
@@ -27,5 +27,5 @@ index aa14e473df..08fee6f7d5 100644
          for (j = 0; j < 6; ++j) {
               pp->frame_refs[i].wmmat[j] = h->cur_frame.gm_params[AV1_REF_FRAME_LAST + i][j];
 -- 
-2.17.1
+2.25.4
 


### PR DESCRIPTION
Since ffmpeg commit https://github.com/FFmpeg/FFmpeg/commit/b4f52019675159f303df05490ac5cf9972e279b2, the query_formats in
AVFilter structure was changed to a union and now
needs to be defined with FILTER_QUERY_FUNC macro.
