### PR TITLE
fix -stream-loop bug caused by 0080 patch

### DIFF
--- a/patches/0080-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
+++ b/patches/0080-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
@@ -60,7 +60,7 @@ index 70ed425ae2c9..6a5e4e9abb3a 100644
 -            q->buffered_count--;
 -            return qsv_decode(avctx, q, frame, got_frame, &zero_pkt);
 -        }
-+    if (q->reinit_flag || !q->session) {
++    if (q->reinit_flag || !q->session || !q->initialized) {
          q->reinit_flag = 0;
 +        ret = qsv_decode_header(avctx, q, pkt, pix_fmt, &param);
 +        if (ret < 0) {

--- a/patches/0081-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
+++ b/patches/0081-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
@@ -42,7 +42,7 @@ index 6a5e4e9abb3a..92a816a34456 100644
 @@ -865,18 +865,28 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
      }
  
-     if (q->reinit_flag || !q->session) {
+     if (q->reinit_flag || !q->session || !q->initialized) {
 +        mfxFrameAllocRequest request;
 +        memset(&request, 0, sizeof(request));
 +


### PR DESCRIPTION
ffmpeg -v verbose -init_hw_device vaapi=va:/dev/dri/renderD128 \
-init_hw_device qsv=hw@va -filter_hw_device hw -c:v h264_qsv \
-stream_loop -1 -i input.mp4 -vf hwupload=extra_hw_frames=64,format=qsv \
-y -c:v hevc_qsv -f null –

fix bug on running this command. This bug is caused by 0080 patch.

After flush codec we should reinit codec as well. Add this condition to code.
q->reinit_flag: param changed in stream.
!q->session: first init codec
!q->initialized: after flush the codec.