### PR TITLE
qsvenc: dump vp9 & mjpeg parameters and fix error for hevc

### DIFF
--- a/patches/0091-lavc-qsvenc-remove-VC1-profiles.patch
+++ b/patches/0091-lavc-qsvenc-remove-VC1-profiles.patch
@@ -1,0 +1,35 @@
+From 30772ffa2c1f17f4a63c14864d02053ddd5694c2 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 8 Dec 2021 12:19:17 +0800
+Subject: [PATCH 91/95] lavc/qsvenc: remove VC1 profiles
+
+The SDK doesn't support VC1 encoding. In addition, both
+MFX_PROFILE_VC1_SIMPLE and MFX_PROFILE_HEVC_MAIN are 1 in the SDK, HEVC
+main profile is recognized as simple profile in the verbose output if
+don't remove VC1 profiles.
+
+$ ffmpeg -v verbose -qsv_device /dev/dri/renderD129 -f lavfi -i
+yuvtestsrc -c:v hevc_qsv -f null -
+
+[hevc_qsv @ 0x55bdf7eb4eb0] profile: simple; level: 21
+---
+ libavcodec/qsvenc.c | 3 ---
+ 1 file changed, 3 deletions(-)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 6845bd1e9b..84d63bed03 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -60,9 +60,6 @@ static const struct {
+     { MFX_PROFILE_MPEG2_SIMPLE,                 "simple"                },
+     { MFX_PROFILE_MPEG2_MAIN,                   "main"                  },
+     { MFX_PROFILE_MPEG2_HIGH,                   "high"                  },
+-    { MFX_PROFILE_VC1_SIMPLE,                   "simple"                },
+-    { MFX_PROFILE_VC1_MAIN,                     "main"                  },
+-    { MFX_PROFILE_VC1_ADVANCED,                 "advanced"              },
+ #if QSV_VERSION_ATLEAST(1, 8)
+     { MFX_PROFILE_HEVC_MAIN,                    "main"                  },
+     { MFX_PROFILE_HEVC_MAIN10,                  "main10"                },
+-- 
+2.17.1
+

--- a/patches/0092-lavc-qsvenc-define-profile-array-per-codec.patch
+++ b/patches/0092-lavc-qsvenc-define-profile-array-per-codec.patch
@@ -1,0 +1,105 @@
+From 7dd7993493ee9ad5404303fbc9318f3c305b1592 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 8 Dec 2021 12:17:06 +0800
+Subject: [PATCH 92/95] lavc/qsvenc: define profile array per codec
+
+The SDK defines HEVC, VP9 and AV1 profiles in the same values
+e.g.
+MFX_PROFILE_HEVC_MAIN             =1,
+MFX_PROFILE_VP9_0                 =1,
+MFX_PROFILE_AV1_MAIN              =1,
+
+To avoid potential errors when adding VP9, AV1 profiles later,
+this patch defines profile array per codec.
+---
+ libavcodec/qsvenc.c | 47 +++++++++++++++++++++++++++++++++++++--------
+ 1 file changed, 39 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 84d63bed03..cf870e0d9f 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -41,10 +41,12 @@
+ #include "qsv_internal.h"
+ #include "qsvenc.h"
+ 
+-static const struct {
++struct profile_names {
+     mfxU16 profile;
+     const char *name;
+-} profile_names[] = {
++};
++
++static const struct profile_names avc_profiles[] = {
+     { MFX_PROFILE_AVC_BASELINE,                 "baseline"              },
+     { MFX_PROFILE_AVC_MAIN,                     "main"                  },
+     { MFX_PROFILE_AVC_EXTENDED,                 "extended"              },
+@@ -57,9 +59,15 @@ static const struct {
+     { MFX_PROFILE_AVC_CONSTRAINED_HIGH,         "constrained high"      },
+     { MFX_PROFILE_AVC_PROGRESSIVE_HIGH,         "progressive high"      },
+ #endif
++};
++
++static const struct profile_names mpeg2_profiles[] = {
+     { MFX_PROFILE_MPEG2_SIMPLE,                 "simple"                },
+     { MFX_PROFILE_MPEG2_MAIN,                   "main"                  },
+     { MFX_PROFILE_MPEG2_HIGH,                   "high"                  },
++};
++
++static const struct profile_names hevc_profiles[] = {
+ #if QSV_VERSION_ATLEAST(1, 8)
+     { MFX_PROFILE_HEVC_MAIN,                    "main"                  },
+     { MFX_PROFILE_HEVC_MAIN10,                  "main10"                },
+@@ -71,12 +79,35 @@ static const struct {
+ #endif
+ };
+ 
+-static const char *print_profile(mfxU16 profile)
++static const char *print_profile(enum AVCodecID codec_id, mfxU16 profile)
+ {
+-    int i;
+-    for (i = 0; i < FF_ARRAY_ELEMS(profile_names); i++)
+-        if (profile == profile_names[i].profile)
+-            return profile_names[i].name;
++    const struct profile_names *profiles;
++    int i, num_profiles;
++
++    switch (codec_id) {
++    case AV_CODEC_ID_H264:
++        profiles = avc_profiles;
++        num_profiles = FF_ARRAY_ELEMS(avc_profiles);
++        break;
++
++    case AV_CODEC_ID_MPEG2VIDEO:
++        profiles = mpeg2_profiles;
++        num_profiles = FF_ARRAY_ELEMS(mpeg2_profiles);
++        break;
++
++    case AV_CODEC_ID_HEVC:
++        profiles = hevc_profiles;
++        num_profiles = FF_ARRAY_ELEMS(hevc_profiles);
++        break;
++
++    default:
++        return "unknown";
++    }
++
++    for (i = 0; i < num_profiles; i++)
++        if (profile == profiles[i].profile)
++            return profiles[i].name;
++
+     return "unknown";
+ }
+ 
+@@ -152,7 +183,7 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
+ #endif
+ 
+     av_log(avctx, AV_LOG_VERBOSE, "profile: %s; level: %"PRIu16"\n",
+-           print_profile(info->CodecProfile), info->CodecLevel);
++           print_profile(avctx->codec_id, info->CodecProfile), info->CodecLevel);
+ 
+     av_log(avctx, AV_LOG_VERBOSE, "GopPicSize: %"PRIu16"; GopRefDist: %"PRIu16"; GopOptFlag: ",
+            info->GopPicSize, info->GopRefDist);
+-- 
+2.17.1
+

--- a/patches/0093-lavc-qsvenc-add-VP9-profiles.patch
+++ b/patches/0093-lavc-qsvenc-add-VP9-profiles.patch
@@ -1,0 +1,44 @@
+From 708fcc2e789cd687982876fc286ade58377c9d27 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 8 Dec 2021 12:35:16 +0800
+Subject: [PATCH 93/95] lavc/qsvenc: add VP9 profiles
+
+---
+ libavcodec/qsvenc.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index cf870e0d9f..1762be2822 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -79,6 +79,15 @@ static const struct profile_names hevc_profiles[] = {
+ #endif
+ };
+ 
++static const struct profile_names vp9_profiles[] = {
++#if QSV_VERSION_ATLEAST(1, 19)
++    { MFX_PROFILE_VP9_0,                        "0"                     },
++    { MFX_PROFILE_VP9_1,                        "1"                     },
++    { MFX_PROFILE_VP9_2,                        "2"                     },
++    { MFX_PROFILE_VP9_3,                        "3"                     },
++#endif
++};
++
+ static const char *print_profile(enum AVCodecID codec_id, mfxU16 profile)
+ {
+     const struct profile_names *profiles;
+@@ -100,6 +109,11 @@ static const char *print_profile(enum AVCodecID codec_id, mfxU16 profile)
+         num_profiles = FF_ARRAY_ELEMS(hevc_profiles);
+         break;
+ 
++    case AV_CODEC_ID_VP9:
++        profiles = vp9_profiles;
++        num_profiles = FF_ARRAY_ELEMS(vp9_profiles);
++        break;
++
+     default:
+         return "unknown";
+     }
+-- 
+2.17.1
+

--- a/patches/0094-lavc-qsvenc-dump-parameters-for-VP9-encoding-in-verb.patch
+++ b/patches/0094-lavc-qsvenc-dump-parameters-for-VP9-encoding-in-verb.patch
@@ -1,0 +1,111 @@
+From b3b6af1f6b18c5f24be03e683bbc19b6e2e1e35d Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 8 Dec 2021 10:11:28 +0800
+Subject: [PATCH 94/95] lavc/qsvenc: dump parameters for VP9 encoding in
+ verbose mode
+
+---
+ libavcodec/qsvenc.c | 80 +++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 80 insertions(+)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 1762be2822..1ee2d10781 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -374,6 +374,84 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
+ #endif
+ }
+ 
++static void dump_video_vp9_param(AVCodecContext *avctx, QSVEncContext *q,
++                                 mfxExtBuffer **coding_opts)
++{
++    mfxInfoMFX *info = &q->param.mfx;
++#if QSV_HAVE_EXT_VP9_PARAM
++    mfxExtVP9Param *vp9_param = (mfxExtVP9Param *)coding_opts[0];
++#endif
++#if QSV_HAVE_CO2
++    mfxExtCodingOption2 *co2 = (mfxExtCodingOption2*)coding_opts[1];
++#endif
++
++    av_log(avctx, AV_LOG_VERBOSE, "profile: %s \n",
++           print_profile(avctx->codec_id, info->CodecProfile));
++
++    av_log(avctx, AV_LOG_VERBOSE, "GopPicSize: %"PRIu16"; GopRefDist: %"PRIu16"; GopOptFlag: ",
++           info->GopPicSize, info->GopRefDist);
++    if (info->GopOptFlag & MFX_GOP_CLOSED)
++        av_log(avctx, AV_LOG_VERBOSE, "closed ");
++    if (info->GopOptFlag & MFX_GOP_STRICT)
++        av_log(avctx, AV_LOG_VERBOSE, "strict ");
++    av_log(avctx, AV_LOG_VERBOSE, "; IdrInterval: %"PRIu16"\n", info->IdrInterval);
++
++    av_log(avctx, AV_LOG_VERBOSE, "TargetUsage: %"PRIu16"; RateControlMethod: %s\n",
++           info->TargetUsage, print_ratecontrol(info->RateControlMethod));
++
++    if (info->RateControlMethod == MFX_RATECONTROL_CBR ||
++        info->RateControlMethod == MFX_RATECONTROL_VBR) {
++        av_log(avctx, AV_LOG_VERBOSE,
++               "BufferSizeInKB: %"PRIu16"; InitialDelayInKB: %"PRIu16"; TargetKbps: %"PRIu16"; MaxKbps: %"PRIu16"; BRCParamMultiplier: %"PRIu16"\n",
++               info->BufferSizeInKB, info->InitialDelayInKB, info->TargetKbps, info->MaxKbps, info->BRCParamMultiplier);
++    } else if (info->RateControlMethod == MFX_RATECONTROL_CQP) {
++        av_log(avctx, AV_LOG_VERBOSE, "QPI: %"PRIu16"; QPP: %"PRIu16"; QPB: %"PRIu16"\n",
++               info->QPI, info->QPP, info->QPB);
++    }
++#if QSV_HAVE_ICQ
++    else if (info->RateControlMethod == MFX_RATECONTROL_ICQ) {
++        av_log(avctx, AV_LOG_VERBOSE, "ICQQuality: %"PRIu16"\n", info->ICQQuality);
++    }
++#endif
++    else {
++        av_log(avctx, AV_LOG_VERBOSE, "Unsupported ratecontrol method: %d \n", info->RateControlMethod);
++    }
++
++    av_log(avctx, AV_LOG_VERBOSE, "NumRefFrame: %"PRIu16"\n", info->NumRefFrame);
++
++#if QSV_HAVE_CO2
++    av_log(avctx, AV_LOG_VERBOSE,
++           "IntRefType: %"PRIu16"; IntRefCycleSize: %"PRIu16"; IntRefQPDelta: %"PRId16"\n",
++           co2->IntRefType, co2->IntRefCycleSize, co2->IntRefQPDelta);
++
++    av_log(avctx, AV_LOG_VERBOSE, "MaxFrameSize: %d; ", co2->MaxFrameSize);
++    av_log(avctx, AV_LOG_VERBOSE, "\n");
++
++    av_log(avctx, AV_LOG_VERBOSE,
++           "BitrateLimit: %s; MBBRC: %s; ExtBRC: %s\n",
++           print_threestate(co2->BitrateLimit), print_threestate(co2->MBBRC),
++           print_threestate(co2->ExtBRC));
++
++#if QSV_HAVE_VDENC
++    av_log(avctx, AV_LOG_VERBOSE, "VDENC: %s\n", print_threestate(info->LowPower));
++#endif
++
++#if QSV_VERSION_ATLEAST(1, 9)
++    av_log(avctx, AV_LOG_VERBOSE,
++           "MinQPI: %"PRIu8"; MaxQPI: %"PRIu8"; MinQPP: %"PRIu8"; MaxQPP: %"PRIu8"; MinQPB: %"PRIu8"; MaxQPB: %"PRIu8"\n",
++           co2->MinQPI, co2->MaxQPI, co2->MinQPP, co2->MaxQPP, co2->MinQPB, co2->MaxQPB);
++#endif
++#endif
++
++    av_log(avctx, AV_LOG_VERBOSE, "FrameRateExtD: %"PRIu32"; FrameRateExtN: %"PRIu32" \n",
++           info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
++
++#if QSV_HAVE_EXT_VP9_PARAM
++    av_log(avctx, AV_LOG_VERBOSE, "WriteIVFHeaders: %s \n",
++           print_threestate(vp9_param->WriteIVFHeaders));
++#endif
++}
++
+ static int select_rc_mode(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     const char *rc_desc;
+@@ -1039,6 +1117,8 @@ static int qsv_retrieve_enc_vp9_params(AVCodecContext *avctx, QSVEncContext *q)
+ 
+     q->packet_size = q->param.mfx.BufferSizeInKB * q->param.mfx.BRCParamMultiplier * 1000;
+ 
++    dump_video_vp9_param(avctx, q, ext_buffers);
++
+     return 0;
+ }
+ 
+-- 
+2.17.1
+

--- a/patches/0095-lavc-qsvenc-dump-parameters-for-mjpeg-encoding-in-ve.patch
+++ b/patches/0095-lavc-qsvenc-dump-parameters-for-mjpeg-encoding-in-ve.patch
@@ -1,0 +1,45 @@
+From 4952f007042259a487b93173d2ce80a79ea79c34 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 8 Dec 2021 15:50:24 +0800
+Subject: [PATCH 95/95] lavc/qsvenc: dump parameters for mjpeg encoding in
+ verbose mode
+
+---
+ libavcodec/qsvenc.c | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 1ee2d10781..7abf1eebdd 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -452,6 +452,18 @@ static void dump_video_vp9_param(AVCodecContext *avctx, QSVEncContext *q,
+ #endif
+ }
+ 
++static void dump_video_mjpeg_param(AVCodecContext *avctx, QSVEncContext *q)
++{
++    mfxInfoMFX *info = &q->param.mfx;
++
++    av_log(avctx, AV_LOG_VERBOSE, "Interleaved: %"PRIu16" \n", info->Interleaved);
++    av_log(avctx, AV_LOG_VERBOSE, "Quality: %"PRIu16" \n", info->Quality);
++    av_log(avctx, AV_LOG_VERBOSE, "RestartInterval: %"PRIu16" \n", info->RestartInterval);
++
++    av_log(avctx, AV_LOG_VERBOSE, "FrameRateExtD: %"PRIu32"; FrameRateExtN: %"PRIu32" \n",
++           info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
++}
++
+ static int select_rc_mode(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     const char *rc_desc;
+@@ -1068,6 +1080,8 @@ static int qsv_retrieve_enc_jpeg_params(AVCodecContext *avctx, QSVEncContext *q)
+     if (q->packet_size == 0)
+         q->packet_size = q->param.mfx.FrameInfo.Height * q->param.mfx.FrameInfo.Width * 4;
+ 
++    dump_video_mjpeg_param(avctx, q);
++
+     return 0;
+ }
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
here is the upstream patchset: https://patchwork.ffmpeg.org/project/ffmpeg/list/?series=5477, and some internal development depends on it. 