### PR TITLE
Update 0009

### DIFF
--- a/patches/0009-lavc-vaapi_encode-add-support-for-maxframesize.patch
+++ b/patches/0009-lavc-vaapi_encode-add-support-for-maxframesize.patch
@@ -1,7 +1,7 @@
-From 70e4427fef205182423ced9ffcae6cef5319d891 Mon Sep 17 00:00:00 2001
+From c69350250850b2d6ca01ae2bd611127436349b04 Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Mon, 22 Jun 2020 09:51:24 +0800
-Subject: [PATCH 09/92] lavc/vaapi_encode: add support for maxframesize
+Subject: [PATCH 09/95] lavc/vaapi_encode: add support for maxframesize
 
 Add support for max frame size:
     - max_frame_size (bytes) to indicate the max allowed size for frame.
@@ -31,7 +31,7 @@ Signed-off-by: Linjie Fu <linjie.fu@intel.com>
  2 files changed, 84 insertions(+), 3 deletions(-)
 
 diff --git a/libavcodec/vaapi_encode.c b/libavcodec/vaapi_encode.c
-index ec054ae70152..bdd6430e2a5a 100644
+index 3bf379b1a0..fdd127aad1 100644
 --- a/libavcodec/vaapi_encode.c
 +++ b/libavcodec/vaapi_encode.c
 @@ -348,7 +348,16 @@ static int vaapi_encode_issue(AVCodecContext *avctx,
@@ -80,7 +80,7 @@ index ec054ae70152..bdd6430e2a5a 100644
 +        av_log(avctx, AV_LOG_WARNING, "Max frame size attribute "
 +                                                "is not supported.\n");
 +    } else {
-+        ctx->delta_qp = av_mallocz_array(MFS_NUM_PASSES, sizeof(uint8_t));
++        ctx->delta_qp = av_calloc(MFS_NUM_PASSES, sizeof(uint8_t));
 +        if (!ctx->delta_qp) {
 +            return AVERROR(ENOMEM);
 +        }
@@ -107,7 +107,7 @@ index ec054ae70152..bdd6430e2a5a 100644
  static av_cold int vaapi_encode_init_gop_structure(AVCodecContext *avctx)
  {
      VAAPIEncodeContext *ctx = avctx->priv_data;
-@@ -2425,6 +2482,12 @@ av_cold int ff_vaapi_encode_init(AVCodecContext *avctx)
+@@ -2427,6 +2484,12 @@ av_cold int ff_vaapi_encode_init(AVCodecContext *avctx)
              goto fail;
      }
  
@@ -120,7 +120,7 @@ index ec054ae70152..bdd6430e2a5a 100644
      vas = vaCreateConfig(ctx->hwctx->display,
                           ctx->va_profile, ctx->va_entrypoint,
                           ctx->config_attributes, ctx->nb_config_attributes,
-@@ -2548,6 +2611,9 @@ av_cold int ff_vaapi_encode_close(AVCodecContext *avctx)
+@@ -2555,6 +2618,9 @@ av_cold int ff_vaapi_encode_close(AVCodecContext *avctx)
          ctx->va_config = VA_INVALID_ID;
      }
  
@@ -131,7 +131,7 @@ index ec054ae70152..bdd6430e2a5a 100644
  
      av_freep(&ctx->codec_sequence_params);
 diff --git a/libavcodec/vaapi_encode.h b/libavcodec/vaapi_encode.h
-index b41604a88329..1c40a734a532 100644
+index b41604a883..1c40a734a5 100644
 --- a/libavcodec/vaapi_encode.h
 +++ b/libavcodec/vaapi_encode.h
 @@ -58,6 +58,11 @@ enum {
@@ -189,5 +189,5 @@ index b41604a88329..1c40a734a532 100644
  #define VAAPI_ENCODE_RC_MODE(name, desc) \
      { #name, desc, 0, AV_OPT_TYPE_CONST, { .i64 = RC_MODE_ ## name }, \
 -- 
-2.25.4
+2.25.1
 


### PR DESCRIPTION
av_mallocz_array was deprecated in FFmpeg, use av_calloc instead