### PR TITLE
Print info message instead of error message for AVERROR(EAGAIN)

### DIFF
--- a/patches/0079-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
+++ b/patches/0079-libavcodec-qsvdec-remove-redundant-decodeHeader.patch
@@ -1,7 +1,7 @@
-From 4a2cb4d71c8357dc8954d4099687286750e6b314 Mon Sep 17 00:00:00 2001
+From 215bf93fe4fe1c855517c629137d13e0e3e5790f Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Tue, 16 Mar 2021 14:31:19 +0800
-Subject: [PATCH 66/74] libavcodec/qsvdec: remove redundant decodeHeader()
+Subject: [PATCH 62/70] libavcodec/qsvdec: remove redundant decodeHeader()
 
 Since ffmpeg-qsv uses return value to reinit decoder, it doesn't need to
 decode header each time. Move qsv_decode_header's position so that
@@ -13,11 +13,11 @@ decoder is drain.
 Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
 Signed-off-by Guangxin Xu <guangxin.xu@intel.com>
 ---
- libavcodec/qsvdec.c | 26 ++++++++++++--------------
- 1 file changed, 12 insertions(+), 14 deletions(-)
+ libavcodec/qsvdec.c | 29 +++++++++++++++--------------
+ 1 file changed, 15 insertions(+), 14 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 1b6d6d2717..d663e95c4c 100644
+index 8ed4609edb..b3ddd7ffdc 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -89,7 +89,6 @@ typedef struct QSVContext {
@@ -37,7 +37,7 @@ index 1b6d6d2717..d663e95c4c 100644
      } else {
          q->zero_consume_run = 0;
      }
-@@ -961,20 +958,21 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+@@ -961,20 +958,24 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
      if (!avctx->coded_height)
          avctx->coded_height = 720;
  
@@ -64,12 +64,15 @@ index 1b6d6d2717..d663e95c4c 100644
          q->reinit_flag = 0;
 +        ret = qsv_decode_header(avctx, q, pkt, pix_fmt, &param);
 +        if (ret < 0) {
-+            av_log(avctx, AV_LOG_ERROR, "Error decoding header\n");
++            if (ret == AVERROR(EAGAIN))
++                av_log(avctx, AV_LOG_INFO, "More data is required to decode header\n");
++            else
++                av_log(avctx, AV_LOG_ERROR, "Error decoding header\n");
 +            goto reinit_fail;
 +        }
  
          q->orig_pix_fmt = avctx->pix_fmt = pix_fmt = ff_qsv_map_fourcc(param.mfx.FrameInfo.FourCC);
  
 -- 
-2.32.0
+2.17.1
 

--- a/patches/0080-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
+++ b/patches/0080-libavcodec-qsvdec-using-suggested-num-to-set-init_po.patch
@@ -1,7 +1,7 @@
-From b2af1e192d4e4ac4e475da0b1a1ce01ec826124b Mon Sep 17 00:00:00 2001
+From a18db98a61767204e709119dff5ebc550f4d4b51 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Tue, 26 Jan 2021 09:55:59 +0800
-Subject: [PATCH 80/88] libavcodec/qsvdec: using suggested num to set
+Subject: [PATCH 63/70] libavcodec/qsvdec: using suggested num to set
  init_pool_size
 
 The init_pool_size is set to be 64 and it is too many.
@@ -18,10 +18,10 @@ Signed-off-by Guangxin Xu <guangxin.xu@intel.com>
  1 file changed, 12 insertions(+), 2 deletions(-)
 
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 6cf5ddd5c6..0b8e77b4e6 100644
+index b3ddd7ffdc..98841c0268 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -88,7 +88,7 @@ typedef struct QSVContext {
+@@ -95,7 +95,7 @@ typedef struct QSVContext {
      uint32_t fourcc;
      mfxFrameInfo frame_info;
      AVBufferPool *pool;
@@ -30,7 +30,7 @@ index 6cf5ddd5c6..0b8e77b4e6 100644
      int initialized;
  
      // options set by the caller
-@@ -288,7 +288,7 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
+@@ -297,7 +297,7 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
          hwframes_ctx->height            = FFALIGN(avctx->coded_height, 32);
          hwframes_ctx->format            = AV_PIX_FMT_QSV;
          hwframes_ctx->sw_format         = avctx->sw_pix_fmt;
@@ -39,7 +39,7 @@ index 6cf5ddd5c6..0b8e77b4e6 100644
          frames_hwctx->frame_type        = MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;
  
          ret = av_hwframe_ctx_init(avctx->hw_frames_ctx);
-@@ -871,18 +871,28 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+@@ -967,6 +967,9 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
      }
  
      if (q->reinit_flag || !q->session || !q->initialized) {
@@ -49,7 +49,8 @@ index 6cf5ddd5c6..0b8e77b4e6 100644
          q->reinit_flag = 0;
          ret = qsv_decode_header(avctx, q, pkt, pix_fmt, &param);
          if (ret < 0) {
-             av_log(avctx, AV_LOG_ERROR, "Error decoding header\n");
+@@ -976,12 +979,19 @@ static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
+                 av_log(avctx, AV_LOG_ERROR, "Error decoding header\n");
              goto reinit_fail;
          }
 +        param.IOPattern = q->iopattern;


### PR DESCRIPTION
Update 0079, 0080

More data is expected when MFXVideoDECODE_DecodeHeader returns
MFX_ERR_MORE_DATA, and AVERROR(EAGAIN) is returned back to the upper
layer, this is right behavior. In order to avoid misleading user, print info
message instead of error message for AVERROR(EAGAIN)