### PR TITLE
Fix timestamp

### DIFF
--- a/patches/0091-libavcodec-qsvenc_av1-add-av1_qsv-encoder.patch
+++ b/patches/0091-libavcodec-qsvenc_av1-add-av1_qsv-encoder.patch
@@ -1,7 +1,7 @@
-From 911904f4f0f178c27d198c5da04258007bbf1134 Mon Sep 17 00:00:00 2001
+From d3d881c526aa758610d6882a1c40dd680f38fc71 Mon Sep 17 00:00:00 2001
 From: "Chen,Wenbin" <wenbin.chen@intel.com>
 Date: Thu, 8 Apr 2021 13:09:47 +0800
-Subject: [PATCH 68/70] libavcodec/qsvenc_av1: add av1_qsv encoder
+Subject: [PATCH] libavcodec/qsvenc_av1: add av1_qsv encoder
 
 It is available when libvpl is enabled
 
@@ -15,10 +15,10 @@ Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
  configure               |   4 +
  libavcodec/Makefile     |   1 +
  libavcodec/allcodecs.c  |   1 +
- libavcodec/qsvenc.c     | 219 +++++++++++++++++++++++++++++++++-
+ libavcodec/qsvenc.c     | 219 ++++++++++++++++++++++++++++++++-
  libavcodec/qsvenc.h     |   7 +-
- libavcodec/qsvenc_av1.c | 253 ++++++++++++++++++++++++++++++++++++++++
- 6 files changed, 481 insertions(+), 4 deletions(-)
+ libavcodec/qsvenc_av1.c | 262 ++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 490 insertions(+), 4 deletions(-)
  create mode 100644 libavcodec/qsvenc_av1.c
 
 diff --git a/configure b/configure
@@ -68,7 +68,7 @@ index 22d56760ec..da72357fba 100644
  extern const FFCodec ff_libopenh264_decoder;
  extern const FFCodec ff_h264_amf_encoder;
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 4cbb1900a6..f3ecaab898 100644
+index 16f472720b..5fc3bfc200 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
 @@ -90,6 +90,14 @@ static const struct profile_names vp9_profiles[] = {
@@ -98,7 +98,7 @@ index 4cbb1900a6..f3ecaab898 100644
      default:
          return "unknown";
      }
-@@ -482,6 +495,115 @@ static void dump_video_mjpeg_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -489,6 +502,115 @@ static void dump_video_mjpeg_param(AVCodecContext *avctx, QSVEncContext *q)
             info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
  }
  
@@ -214,7 +214,7 @@ index 4cbb1900a6..f3ecaab898 100644
  static int select_rc_mode(AVCodecContext *avctx, QSVEncContext *q)
  {
      const char *rc_desc;
-@@ -820,9 +942,16 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -827,9 +949,16 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
      case MFX_RATECONTROL_CQP:
          quant = avctx->global_quality / FF_QP2LAMBDA;
  
@@ -234,7 +234,7 @@ index 4cbb1900a6..f3ecaab898 100644
  
          break;
  #if QSV_HAVE_AVBR
-@@ -956,6 +1085,17 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -963,6 +1092,17 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
              q->extco2.Header.BufferId = MFX_EXTBUFF_CODING_OPTION2;
              q->extco2.Header.BufferSz = sizeof(q->extco2);
  
@@ -252,7 +252,7 @@ index 4cbb1900a6..f3ecaab898 100644
              q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extco2;
          }
  #endif
-@@ -1036,6 +1176,21 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1053,6 +1193,21 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
      }
  #endif
  
@@ -274,7 +274,7 @@ index 4cbb1900a6..f3ecaab898 100644
  #if QSV_HAVE_EXT_HEVC_TILES
      if (avctx->codec_id == AV_CODEC_ID_HEVC) {
          q->exthevctiles.Header.BufferId = MFX_EXTBUFF_HEVC_TILES;
-@@ -1159,6 +1314,61 @@ static int qsv_retrieve_enc_vp9_params(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1176,6 +1331,61 @@ static int qsv_retrieve_enc_vp9_params(AVCodecContext *avctx, QSVEncContext *q)
      return 0;
  }
  
@@ -336,7 +336,7 @@ index 4cbb1900a6..f3ecaab898 100644
  static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
  {
      AVCPBProperties *cpb_props;
-@@ -1517,6 +1727,9 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1534,6 +1744,9 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
      case AV_CODEC_ID_VP9:
          ret = qsv_retrieve_enc_vp9_params(avctx, q);
          break;
@@ -347,7 +347,7 @@ index 4cbb1900a6..f3ecaab898 100644
          ret = qsv_retrieve_enc_params(avctx, q);
          break;
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index c9ba792d4a..bd4818898b 100644
+index 91908f0d5d..f9c58c2ce7 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -46,6 +46,7 @@
@@ -358,7 +358,7 @@ index c9ba792d4a..bd4818898b 100644
  
  #define QSV_HAVE_TRELLIS QSV_VERSION_ATLEAST(1, 8)
  #define QSV_HAVE_MAX_SLICE_SIZE QSV_VERSION_ATLEAST(1, 9)
-@@ -146,6 +147,10 @@ typedef struct QSVEncContext {
+@@ -149,6 +150,10 @@ typedef struct QSVEncContext {
  #if QSV_HAVE_EXT_VP9_PARAM
      mfxExtVP9Param  extvp9param;
  #endif
@@ -369,7 +369,7 @@ index c9ba792d4a..bd4818898b 100644
  
  #if QSV_HAVE_OPAQUE
      mfxExtOpaqueSurfaceAlloc opaque_alloc;
-@@ -156,7 +161,7 @@ typedef struct QSVEncContext {
+@@ -159,7 +164,7 @@ typedef struct QSVEncContext {
      mfxExtVideoSignalInfo extvsi;
  
      mfxExtBuffer  *extparam_internal[3 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + (QSV_HAVE_MF * 2) +
@@ -380,10 +380,10 @@ index c9ba792d4a..bd4818898b 100644
      mfxExtBuffer **extparam;
 diff --git a/libavcodec/qsvenc_av1.c b/libavcodec/qsvenc_av1.c
 new file mode 100644
-index 0000000000..be2a482947
+index 0000000000..25c349aba3
 --- /dev/null
 +++ b/libavcodec/qsvenc_av1.c
-@@ -0,0 +1,253 @@
+@@ -0,0 +1,262 @@
 +/*
 + * Intel MediaSDK QSV based AV1 encoder
 + *
@@ -428,7 +428,7 @@ index 0000000000..be2a482947
 +    AVFifo *packet_fifo;
 +    int64_t parsed_packet_offset;
 +    AVPacket output_pkt;
-+    int load_plugin;
++    int64_t last_pts;
 +} QSVAV1EncContext;
 +
 +static av_cold int qsv_enc_init(AVCodecContext *avctx)
@@ -491,7 +491,8 @@ index 0000000000..be2a482947
 +    return 0;
 +}
 +
-+static int qsv_reorder_bitstream(QSVAV1EncContext *q, AVPacket *pkt, int *got_packet)
++static int qsv_reorder_bitstream(AVCodecContext *avctx, QSVAV1EncContext *q,
++                                 AVPacket *pkt, int *got_packet)
 +{
 +    int ret = 0;
 +    int64_t offset = 0;
@@ -530,6 +531,14 @@ index 0000000000..be2a482947
 +            if (ret < 0)
 +                return ret;
 +            av_packet_move_ref(pkt, output_pkt);
++            // Timestamp need to be calculated because pkt is reorded.
++            if (pkt->pts <= q->last_pts) {
++                int64_t duration = av_rescale_q(1,
++                        (AVRational){avctx->framerate.den, avctx->framerate.num},
++                        avctx->time_base);
++                q->last_pts = pkt->dts = pkt->pts = q->last_pts + duration;
++            } else
++                q->last_pts = pkt->dts = pkt->pts;
 +            *got_packet = 1;
 +        }
 +        q->parsed_packet_offset += offset;
@@ -555,7 +564,7 @@ index 0000000000..be2a482947
 +    if (ret < 0)
 +        return ret;
 +
-+    ret = qsv_reorder_bitstream(q, pkt, got_packet);
++    ret = qsv_reorder_bitstream(avctx, q, pkt, got_packet);
 +    if (ret < 0)
 +        return ret;
 +
@@ -638,5 +647,5 @@ index 0000000000..be2a482947
 +    .hw_configs     = ff_qsv_enc_hw_configs,
 +};
 -- 
-2.17.1
+2.32.0
 


### PR DESCRIPTION
Fix TimeStamp so that there is no warning when encode av1. We split one packets into several packets. I assume these packets has fixed framerate and fill pts for these packets. 