### PR TITLE
Add adaptive_i adaptive_b to hevc_qsv..

### DIFF
--- a/patches/0099-libavcodec-qsvenc-Add-adaptive_i-b-to-hevc_qsv.patch
+++ b/patches/0099-libavcodec-qsvenc-Add-adaptive_i-b-to-hevc_qsv.patch
@@ -1,0 +1,63 @@
+From b8dedad8c443d672a0c5ad1aaf396bc9ea1a531f Mon Sep 17 00:00:00 2001
+From: Wenbin Chen <wenbin.chen@intel.com>
+Date: Wed, 18 May 2022 16:15:17 +0800
+Subject: [PATCH] libavcodec/qsvenc: Add adaptive_i/b to hevc_qsv
+
+Add adaptive_i/b feature to hevc_qsv. Adaptive_i allows changing of
+frame type from P and B to I. Adaptive_b allows changing of frame type
+frome B to P.
+
+Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
+---
+ doc/encoders.texi   | 7 +++++++
+ libavcodec/qsvenc.c | 9 ++++-----
+ 2 files changed, 11 insertions(+), 5 deletions(-)
+
+diff --git a/doc/encoders.texi b/doc/encoders.texi
+index d5819ef005..72c4f13378 100644
+--- a/doc/encoders.texi
++++ b/doc/encoders.texi
+@@ -3512,6 +3512,13 @@ Setting this flag turns on or off LowDelayBRC feautre in qsv plugin, which provi
+ more accurate bitrate control to minimize the variance of bitstream size frame
+ by frame. Value: -1-default 0-off 1-on
+ 
++@item @var{adaptive_i}
++This flag controls insertion of I frames by the QSV encoder. Turn ON this flag
++to allow changing of frame type from P and B to I.
++
++@item @var{adaptive_b}
++This flag controls changing of frame type from B to P.
++
+ @item @var{p_strategy}
+ Enable P-pyramid: 0-default 1-simple 2-pyramid(bf need to be set to 0).
+ 
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index f9d5a62e78..732aa74620 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -1041,11 +1041,6 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+ #if QSV_VERSION_ATLEAST(1, 8)
+             q->extco2.LookAheadDS = q->look_ahead_downsampling;
+             q->extco2.RepeatPPS   = q->repeat_pps ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+-
+-            if (q->adaptive_i >= 0)
+-                q->extco2.AdaptiveI = q->adaptive_i ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+-            if (q->adaptive_b >= 0)
+-                q->extco2.AdaptiveB = q->adaptive_b ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+ #endif
+         }
+ 
+@@ -1071,6 +1066,10 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+ #if QSV_VERSION_ATLEAST(1, 8)
+             if (q->b_strategy >= 0)
+                 q->extco2.BRefType = q->b_strategy ? MFX_B_REF_PYRAMID : MFX_B_REF_OFF;
++            if (q->adaptive_i >= 0)
++                q->extco2.AdaptiveI = q->adaptive_i ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
++            if (q->adaptive_b >= 0)
++                q->extco2.AdaptiveB = q->adaptive_b ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+ #endif
+ #if QSV_VERSION_ATLEAST(1, 9)
+             if (avctx->qmin >= 0 && avctx->qmax >= 0 && avctx->qmin > avctx->qmax) {
+-- 
+2.32.0
+


### PR DESCRIPTION
Adaptive I/B for hevc is support on OneVPL, so submit patch to cartwheel until OneVPL is supported on upstream.