### PR TITLE
[patches] fix 0035 HEVC SCC 444 8bit

### DIFF
--- a/patches/0034-FFmpeg-vaapi-HEVC-SCC-encode.patch
+++ b/patches/0034-FFmpeg-vaapi-HEVC-SCC-encode.patch
@@ -12,7 +12,7 @@ Main10:
 ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose -f rawvideo -pix_fmt p010 -s:v 320x240 -r:v 30 -i 320x240_100.p010 -vf 'format=p010,hwupload' -c:v hevc_vaapi -profile:v scc -rc_mode CQP -g 30 -slices 1 -bf 3  -low_power 1 -vframes 150 -y out.h265
 
 Main 444:
-ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose -f rawvideo -pix_fmt 0yuv -s:v 320x240 -r:v 30 -i 320x240_100.ayuv -vf 'format=0yuv,hwupload' -c:v hevc_vaapi -profile:v scc -rc_mode CQP -g 30 -slices 1 -bf 3  -low_power 1 -vframes 150 -y out.h265
+ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose -f rawvideo -pix_fmt vuyx -s:v 320x240 -r:v 30 -i 320x240_100.ayuv -vf 'format=vuyx,hwupload' -c:v hevc_vaapi -profile:v scc -rc_mode CQP -g 30 -slices 1 -bf 3  -low_power 1 -vframes 150 -y out.h265
 
 Main 444-10:
 ffmpeg -hwaccel vaapi -vaapi_device /dev/dri/renderD128 -v verbose -f rawvideo -pix_fmt y410 -s:v 320x240 -r:v 30 -i 320x240_100.y410 -vf 'format=y410,hwupload' -c:v hevc_vaapi -profile:v scc -rc_mode CQP -g 30 -slices 1 -bf 3  -low_power 1 -vframes 150 -y out.h265

--- a/patches/0035-lavc-avcodec-Add-FF_PROFILE_HEVC_SCC-for-screen-cont.patch
+++ b/patches/0035-lavc-avcodec-Add-FF_PROFILE_HEVC_SCC-for-screen-cont.patch
@@ -1,18 +1,17 @@
-From 4012b28833132d875b0b91bceae3f3f4906ca4e0 Mon Sep 17 00:00:00 2001
+From 4453e6c4c649b387038bff79c46c9a4909455eca Mon Sep 17 00:00:00 2001
 From: Linjie Fu <linjie.fu@intel.com>
 Date: Thu, 10 Sep 2020 14:42:39 +0800
-Subject: [PATCH 30/72] lavc/avcodec: Add FF_PROFILE_HEVC_SCC for screen
+Subject: [PATCH 19/60] lavc/avcodec: Add FF_PROFILE_HEVC_SCC for screen
  content coding
 
 Signed-off-by: Linjie Fu <linjie.justin.fu@gmail.com>
 ---
- libavcodec/hevc_ps.c           | 2 ++
- libavcodec/profiles.c          | 1 +
- libavcodec/vaapi_encode_h265.c | 2 +-
- 3 files changed, 4 insertions(+), 1 deletion(-)
+ libavcodec/hevc_ps.c  | 2 ++
+ libavcodec/profiles.c | 1 +
+ 2 files changed, 3 insertions(+)
 
 diff --git a/libavcodec/hevc_ps.c b/libavcodec/hevc_ps.c
-index f665d8053c..86479d1813 100644
+index f665d8053c53..86479d1813fd 100644
 --- a/libavcodec/hevc_ps.c
 +++ b/libavcodec/hevc_ps.c
 @@ -278,6 +278,8 @@ static int decode_profile_tier_level(GetBitContext *gb, AVCodecContext *avctx,
@@ -25,7 +24,7 @@ index f665d8053c..86479d1813 100644
          av_log(avctx, AV_LOG_WARNING, "Unknown HEVC profile: %d\n", ptl->profile_idc);
  
 diff --git a/libavcodec/profiles.c b/libavcodec/profiles.c
-index 7af7fbeb13..2230fc5415 100644
+index 7af7fbeb1302..2230fc5415d0 100644
 --- a/libavcodec/profiles.c
 +++ b/libavcodec/profiles.c
 @@ -85,6 +85,7 @@ const AVProfile ff_hevc_profiles[] = {
@@ -36,19 +35,6 @@ index 7af7fbeb13..2230fc5415 100644
      { FF_PROFILE_UNKNOWN },
  };
  
-diff --git a/libavcodec/vaapi_encode_h265.c b/libavcodec/vaapi_encode_h265.c
-index 0798463ebf..30836795d7 100644
---- a/libavcodec/vaapi_encode_h265.c
-+++ b/libavcodec/vaapi_encode_h265.c
-@@ -1317,7 +1317,7 @@ static const VAAPIEncodeProfile vaapi_encode_h265_profiles[] = {
-     { FF_PROFILE_HEVC_REXT,    12, 3, 0, 0, VAProfileHEVCMain444_12 },
-     { FF_PROFILE_HEVC_SCC,      8, 3, 1, 1, VAProfileHEVCSccMain    },
-     { FF_PROFILE_HEVC_SCC,     10, 3, 1, 1, VAProfileHEVCSccMain10  },
--    { FF_PROFILE_HEVC_SCC,      8, 3, 0, 0, VAProfileHEVCSccMain444 },
-+    { FF_PROFILE_HEVC_SCC,      8, 4, 0, 0, VAProfileHEVCSccMain444 },
- #endif
- #if VA_CHECK_VERSION(1, 9, 0)
-     { FF_PROFILE_HEVC_SCC,     10, 3, 0, 0, VAProfileHEVCSccMain444_10 },
 -- 
-2.17.1
+2.37.2
 


### PR DESCRIPTION
vaapi uses VUYX since https://patchwork.ffmpeg.org/project/ffmpeg/list/?series=7259