### PR TITLE
patches/0050: Fix unknown H264SEIFramePacking type

### DIFF
--- a/patches/0050-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
+++ b/patches/0050-libavcodec-qsvdec.c-extract-frame-packing-arrangemen.patch
@@ -1,4 +1,4 @@
-From 28733758442d2f93fee3f4a8fd12412e8721e76d Mon Sep 17 00:00:00 2001
+From 5a238bf14f83205162f724c44be780c29b8ff155 Mon Sep 17 00:00:00 2001
 From: Wenbinc-Bin <wenbin.chen@intel.com>
 Date: Mon, 18 Jan 2021 16:22:29 +0800
 Subject: [PATCH 21/45] libavcodec/qsvdec.c: extract frame packing arrangement
@@ -16,7 +16,7 @@ Sigend-off-by: Tong Wu <tong1.wu@intel.com>
  2 files changed, 157 insertions(+)
 
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 5119ef4dff..97980afca1 100644
+index 5119ef4dffa6..97980afca1b2 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -57,6 +57,8 @@
@@ -29,7 +29,7 @@ index 5119ef4dff..97980afca1 100644
      (MFX_VERSION_MAJOR > (MAJOR) ||         \
       MFX_VERSION_MAJOR == (MAJOR) && MFX_VERSION_MINOR >= (MINOR))
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 92bfea196e..95c39771b3 100644
+index 92bfea196e47..d14c01ec36ce 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
 @@ -42,13 +42,16 @@
@@ -67,7 +67,7 @@ index 92bfea196e..95c39771b3 100644
  
  #endif
  
-+static int h264_decode_fpa(H264SEIFramePacking *fpa, AVFrame *frame)
++static int h264_decode_fpa(H2645SEIFramePacking *fpa, AVFrame *frame)
 +{
 +    if (!fpa || !frame) {
 +        return AVERROR(EINVAL);
@@ -152,7 +152,7 @@ index 92bfea196e..95c39771b3 100644
 +
 +    switch (q->payload.Type) {
 +    case SEI_TYPE_FRAME_PACKING_ARRANGEMENT:
-+        ret = h264_decode_fpa(&q->sei.frame_packing, frame);
++        ret = h264_decode_fpa(&q->sei.common.frame_packing, frame);
 +        break;
 +    default:
 +        break;
@@ -232,5 +232,5 @@ index 92bfea196e..95c39771b3 100644
  
  static int qsv_process_data(AVCodecContext *avctx, QSVContext *q,
 -- 
-2.25.1
+2.37.3
 


### PR DESCRIPTION
Since commit 33239ebd076d936d51d35f47b3f9837987472b5a

  Author:     Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
  AuthorDate: Mon Jun 27 16:33:24 2022 +0200
  Commit:     Andreas Rheinhardt <andreas.rheinhardt@outlook.com>
  CommitDate: Thu Dec 1 11:00:40 2022 +0100

      avcodec/h2645_sei: Factor parsing common SEI messages out

...H264SEIFramePacking is now merged into H2645SEIFramePacking type.  Thus, fixup patch 0050 (qsvdec extract frame packing).

cc: @wenbinc-Bin @tong1wu 