### PR TITLE
Update 0061

### DIFF
--- a/patches/0061-Clean-up-QSV-filters.patch
+++ b/patches/0061-Clean-up-QSV-filters.patch
@@ -1,4 +1,4 @@
-From 70ea52fa991e3a4f78f98a6b8a3e7c65ce356fda Mon Sep 17 00:00:00 2001
+From 9b2840960f26dc44d7113d25d9e5dd27da5ae8c2 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 28 Apr 2021 09:25:11 +0800
 Subject: [PATCH 28/45] Clean-up QSV filters
@@ -7,21 +7,21 @@ This is the combination of
 https://patchwork.ffmpeg.org/project/ffmpeg/list/?series=4467
 ---
  libavfilter/Makefile             |   4 +-
- libavfilter/qsvvpp.c             |  58 ++-
+ libavfilter/qsvvpp.c             |  61 ++-
  libavfilter/qsvvpp.h             |  11 +-
  libavfilter/vf_deinterlace_qsv.c | 611 ----------------------------
  libavfilter/vf_overlay_qsv.c     |  11 +-
  libavfilter/vf_scale_qsv.c       | 663 -------------------------------
  libavfilter/vf_vpp_qsv.c         | 397 ++++++++++++------
- 7 files changed, 319 insertions(+), 1436 deletions(-)
+ 7 files changed, 322 insertions(+), 1436 deletions(-)
  delete mode 100644 libavfilter/vf_deinterlace_qsv.c
  delete mode 100644 libavfilter/vf_scale_qsv.c
 
 diff --git a/libavfilter/Makefile b/libavfilter/Makefile
-index 3c6a7b03f4..b97b0fea64 100644
+index 5783be281d..ff67e3a0fb 100644
 --- a/libavfilter/Makefile
 +++ b/libavfilter/Makefile
-@@ -257,7 +257,7 @@ OBJS-$(CONFIG_DECONVOLVE_FILTER)             += vf_convolve.o framesync.o
+@@ -259,7 +259,7 @@ OBJS-$(CONFIG_DECONVOLVE_FILTER)             += vf_convolve.o framesync.o
  OBJS-$(CONFIG_DEDOT_FILTER)                  += vf_dedot.o
  OBJS-$(CONFIG_DEFLATE_FILTER)                += vf_neighbor.o
  OBJS-$(CONFIG_DEFLICKER_FILTER)              += vf_deflicker.o
@@ -30,7 +30,7 @@ index 3c6a7b03f4..b97b0fea64 100644
  OBJS-$(CONFIG_DEINTERLACE_VAAPI_FILTER)      += vf_deinterlace_vaapi.o vaapi_vpp.o
  OBJS-$(CONFIG_DEJUDDER_FILTER)               += vf_dejudder.o
  OBJS-$(CONFIG_DELOGO_FILTER)                 += vf_delogo.o
-@@ -443,7 +443,7 @@ OBJS-$(CONFIG_SCALE_FILTER)                  += vf_scale.o scale_eval.o
+@@ -445,7 +445,7 @@ OBJS-$(CONFIG_SCALE_FILTER)                  += vf_scale.o scale_eval.o
  OBJS-$(CONFIG_SCALE_CUDA_FILTER)             += vf_scale_cuda.o scale_eval.o \
                                                  vf_scale_cuda.ptx.o cuda/load_helper.o
  OBJS-$(CONFIG_SCALE_NPP_FILTER)              += vf_scale_npp.o scale_eval.o
@@ -40,7 +40,7 @@ index 3c6a7b03f4..b97b0fea64 100644
  OBJS-$(CONFIG_SCALE_VULKAN_FILTER)           += vf_scale_vulkan.o vulkan.o vulkan_filter.o
  OBJS-$(CONFIG_SCALE2REF_FILTER)              += vf_scale.o scale_eval.o
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 064b105a17..bd2e246a80 100644
+index 064b105a17..7b384ad4dd 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -682,16 +682,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
@@ -140,25 +140,28 @@ index 064b105a17..bd2e246a80 100644
  
      while (s->eof && av_fifo_read(s->async_fifo, &aframe, 1) >= 0) {
          if (MFXVideoCORE_SyncOperation(s->session, aframe.sync, 1000) < 0)
-@@ -889,8 +891,24 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
+@@ -889,8 +891,27 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
                  return AVERROR(EAGAIN);
              break;
          }
 -        out_frame->frame->pts = av_rescale_q(out_frame->surface.Data.TimeStamp,
 -                                             default_tb, outlink->time_base);
 +
-+        /* TODO: calculate the PTS for other cases */
-+        if (s->deinterlace_enabled &&
-+            s->last_in_pts != AV_NOPTS_VALUE &&
-+            ret == MFX_ERR_MORE_SURFACE &&
-+            out_frame->surface.Data.TimeStamp == MFX_TIMESTAMP_UNKNOWN)
-+            dpts = (in_frame->frame->pts - s->last_in_pts) / 2;
-+        else
-+            dpts = 0;
++        if (s->deinterlace_enabled) {
++            if (s->last_in_pts != AV_NOPTS_VALUE &&
++                ret == MFX_ERR_MORE_SURFACE &&
++                out_frame->surface.Data.TimeStamp == MFX_TIMESTAMP_UNKNOWN)
++                dpts = (in_frame->frame->pts - s->last_in_pts) / 2;
++            else
++                dpts = 0;
 +
-+        out_frame->frame->pts = av_rescale_q(in_frame->frame->pts - dpts,
-+                                             inlink->time_base,
-+                                             outlink->time_base);
++            out_frame->frame->pts = av_rescale_q(in_frame->frame->pts - dpts,
++                                                 inlink->time_base,
++                                                 outlink->time_base);
++        } else {
++            out_frame->frame->pts = av_rescale_q(out_frame->surface.Data.TimeStamp,
++                                                 default_tb, outlink->time_base);
++        }
 +
 +        if (outlink->frame_rate.num && outlink->frame_rate.den)
 +            out_frame->frame->duration = av_rescale_q(1, av_inv_q(outlink->frame_rate), outlink->time_base);
@@ -167,7 +170,7 @@ index 064b105a17..bd2e246a80 100644
  
          out_frame->queued++;
          aframe = (QSVAsyncFrame){ sync, out_frame };
-@@ -920,6 +938,8 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
+@@ -920,6 +941,8 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
          }
      } while(ret == MFX_ERR_MORE_SURFACE);
  


### PR DESCRIPTION
Fix incorrect pts in framerate

$ ffmpeg -hwaccel qsv -i input.mp4 -vf "vpp_qsv=framerate=60" -f null - ...
[null @ 0x560658fc4c40] Application provided invalid, non monotonically increasing dts to muxer in stream 0: 556 >= 556

Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>